### PR TITLE
layout test now uses boxfish-haxe, NpmArtifactory for source-map

### DIFF
--- a/gradle-spaghetti-plugin/src/main/groovy/com/prezi/spaghetti/gradle/ObfuscateBundle.groovy
+++ b/gradle-spaghetti-plugin/src/main/groovy/com/prezi/spaghetti/gradle/ObfuscateBundle.groovy
@@ -67,7 +67,7 @@ class ObfuscateBundle extends AbstractBundleTask
 	}
 
 	Set<String> additionalSymbols = []
-	String nodeSourceMapRoot = "${project.buildDir}/node_modules"
+	String nodeSourceMapRoot = null;
 
 	@InputFiles
 	Set<File> getClosureExterns()

--- a/gradle-spaghetti-plugin/src/main/groovy/com/prezi/spaghetti/gradle/SourceMap.groovy
+++ b/gradle-spaghetti-plugin/src/main/groovy/com/prezi/spaghetti/gradle/SourceMap.groovy
@@ -29,7 +29,10 @@ console.log(JSON.stringify(mapAtoC));
 
 		def mapAtoCBuilder = new StringBuilder();
 		def processBuilder = new ProcessBuilder("node", nodeJsFile.toString())
-		processBuilder.environment().put("NODE_PATH", nodeSourceMapRoot)
+		// if user gives a node_modules path use that, otherwise just assume it's there (e.g. global install)
+		if (nodeSourceMapRoot != null) {
+			processBuilder.environment().put("NODE_PATH", nodeSourceMapRoot)
+		}
 		def process = processBuilder.start();
 		process.waitForProcessOutput(mapAtoCBuilder, System.err);
 

--- a/gradle-spaghetti-plugin/src/test/at/build.gradle
+++ b/gradle-spaghetti-plugin/src/test/at/build.gradle
@@ -14,12 +14,8 @@ buildscript {
 		classpath "com.prezi.gradle:gradle-prezi-plugin:2.0-SNAPSHOT"
 		classpath "com.prezi.gradle:gradle-haxe-plugin:2.0-SNAPSHOT"
 		classpath "com.prezi.spaghetti:gradle-spaghetti-plugin:1.3-SNAPSHOT"
-		classpath "com.prezi.boxfish:gradle-boxfish-plugin:1.0-SNAPSHOT"
 	}
 }
-
-
-apply plugin: "spaghetti"
 
 configure(allprojects) {
 	group = "prezi.test"
@@ -44,6 +40,8 @@ configure(subprojects) {
 		}
 	}
 }
+
+apply plugin: "spaghetti"
 
 task resolveStack(type:com.prezi.spaghetti.gradle.ResolveStack) {
 }

--- a/gradle-spaghetti-plugin/src/test/at/layout/build.gradle
+++ b/gradle-spaghetti-plugin/src/test/at/layout/build.gradle
@@ -1,16 +1,7 @@
 import com.prezi.spaghetti.gradle.BundleModule
 import com.prezi.spaghetti.gradle.ObfuscateBundle
-import com.prezi.gradle.boxfish.NpmArtifactory
 
-apply plugin: "boxfish-haxe"
-
-configurations {
-	obfuscateNpm
-}
-
-dependencies {
-	obfuscateNpm group: "npm", name: "source-map", version: "0.1.33", ext: "zip"
-}
+apply plugin: "haxe"
 
 spaghetti {
 	platform "haxe"
@@ -41,10 +32,19 @@ task bundleModule(type: BundleModule) {
 	inputFile compileJs.outputFile
 }
 
-task npmObfuscate(type: NpmArtifactory) {
-	config configurations.obfuscateNpm
+task obfuscate(type: ObfuscateBundle) {
+	dependsOn bundleModule
+	inputFile bundleModule.outputFile
 }
 
-obfuscateJsModule {
-	dependsOn npmObfuscate
+artifacts {
+	archives(bundleModule.outputFile) {
+		builtBy bundleModule
+	}
+	modules(bundleModule.outputFile) {
+		builtBy bundleModule
+	}
+	modulesObf(obfuscate.outputFile) {
+		builtBy obfuscate
+	}
 }


### PR DESCRIPTION
This _should_ make the obfuscation/source-map fiasco go away
See gradle-spaghetti-plugin/src/test/at/layout/build.gradle on how to configure obfuscation
Needs https://github.com/prezi/boxfish-tools/pull/3
