### PR TITLE
Exports fix

### DIFF
--- a/spaghetti-core/src/main/groovy/com/prezi/spaghetti/Wrapper.groovy
+++ b/spaghetti-core/src/main/groovy/com/prezi/spaghetti/Wrapper.groovy
@@ -46,7 +46,7 @@ class Wrapper {
 		moduleNames.eachWithIndex { moduleName, index ->
 			modules.push(""""${moduleName}": arguments[${index}]""")
 		}
-		return """${function}([${fileNames.join(",")}], function() { var __modules = { ${modules.join(",")} }; exports = exports || {}; ${contents}
+		return """${function}([${fileNames.join(",")}], function() { var __modules = { ${modules.join(",")} }; ${contents}
 });
 """
 	}

--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeGenerator.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeGenerator.groovy
@@ -31,8 +31,12 @@ class HaxeGenerator implements Generator {
 	@Override
 	String processModuleJavaScript(ModuleDefinition module, String javaScript)
 	{
+		/* the "exports" line is needed because if this module is
+		   requirejs'd from a nodejs module 'exports' will not be
+		   visible for some reason
+		*/
 		return \
-"""var __module; ${javaScript}
+"""var __module; var exports = exports || {}; ${javaScript}
 return __module;
 """
 	}


### PR DESCRIPTION
Under some (unknown for now) circumstances haxe generates code that refers to NodeJS's "exports" global var if "window" is not found. If a top level node application imports this module with requirejs this exports object will be undefined.
Our hypothesis is that this is because requirejs 'eval's the imported .js and does not pass in the "exports" global object.
This is a hack around this that simply creates an empty object when wrapping modules as requirejs
