### PR TITLE
enum abstract is a Null<Int>

### DIFF
--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeEnumGeneratorVisitor.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeEnumGeneratorVisitor.groovy
@@ -15,7 +15,7 @@ class HaxeEnumGeneratorVisitor extends StringModuleVisitorBase {
 		}
 
 		return \
-"""abstract ${enumName}(Int) {
+"""abstract ${enumName}(Null<Int>) {
 ${values.join("\n")}
 
 	static var _values:Array<${enumName}> = [ ${node.values.join(", ")} ];

--- a/spaghetti-haxe-support/src/test/groovy/com/prezi/spaghetti/haxe/HaxeEnumGeneratorVisitorTest.groovy
+++ b/spaghetti-haxe-support/src/test/groovy/com/prezi/spaghetti/haxe/HaxeEnumGeneratorVisitorTest.groovy
@@ -23,7 +23,7 @@ class HaxeEnumGeneratorVisitorTest extends AstTestBase {
 		def visitor = new HaxeEnumGeneratorVisitor()
 
 		expect:
-		visitor.visit(parser.node) == """abstract MyEnum(Int) {
+		visitor.visit(parser.node) == """abstract MyEnum(Null<Int>) {
 	/**
 	 * Alma.
 	 */


### PR DESCRIPTION
This Null<> is simply erased in the JS backend, but saves a lot of hassle in the a java backend
