### PR TITLE
Add extern for HTMLElement

### DIFF
--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeJsHtmlExterns.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeJsHtmlExterns.groovy
@@ -182,6 +182,7 @@ final class HaxeJsHtmlExterns {
 			HTMLDetailsElement: "js.html.DetailsElement",
 			HTMLDirectoryElement: "js.html.DirectoryElement",
 			HTMLDivElement: "js.html.DivElement",
+			HTMLElement: "js.html.HtmlElement",
 			HTMLEmbedElement: "js.html.EmbedElement",
 			HTMLFieldSetElement: "js.html.FieldSetElement",
 			HTMLFontElement: "js.html.FontElement",

--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeJsHtmlExterns.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeJsHtmlExterns.groovy
@@ -32,11 +32,13 @@ while (<>) {
 	}
 	close $file;
 }
-
 foreach my $undef (@undefs) {
 	# print "Problematic $undef"
 }
- */
+
+print 'Add if missing: HTMLElement: "js.html.Element",'
+
+*/
 final class HaxeJsHtmlExterns {
 	public static final def EXTERNS = [
 			AbstractWorker: "js.html.AbstractWorker",
@@ -182,7 +184,7 @@ final class HaxeJsHtmlExterns {
 			HTMLDetailsElement: "js.html.DetailsElement",
 			HTMLDirectoryElement: "js.html.DirectoryElement",
 			HTMLDivElement: "js.html.DivElement",
-			HTMLElement: "js.html.HtmlElement",
+			HTMLElement: "js.html.Element",
 			HTMLEmbedElement: "js.html.EmbedElement",
 			HTMLFieldSetElement: "js.html.FieldSetElement",
 			HTMLFontElement: "js.html.FontElement",


### PR DESCRIPTION
There was only a mapping for HTMLHtmlElement which is the <HTML> tag.
HTMLElement is not properly implemented in Haxe. See issue: https://github.com/HaxeFoundation/haxe/issues/3644