### PR TITLE
Transitive blocking

### DIFF
--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/PackageApplication.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/PackageApplication.java
@@ -1,6 +1,6 @@
 package com.prezi.spaghetti.gradle;
 
-import com.prezi.spaghetti.bundle.ModuleBundle;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 import com.prezi.spaghetti.gradle.internal.AbstractSpaghettiTask;
 import com.prezi.spaghetti.packaging.ApplicationPackageParameters;
 import com.prezi.spaghetti.packaging.ApplicationType;
@@ -13,7 +13,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static com.prezi.spaghetti.gradle.internal.TextFileUtils.getText;
@@ -145,7 +144,7 @@ public class PackageApplication extends AbstractSpaghettiTask {
 	@TaskAction
 	@SuppressWarnings("UnusedDeclaration")
 	public void makeBundle() throws IOException {
-		Set<ModuleBundle> bundles = lookupBundles();
+		ModuleBundleSet bundles = lookupBundles();
 		getLogger().info("Creating {} application in {}", getType().getDescription(), getOutputDirectory());
 		getType().getPackager().packageApplicationDirectory(getOutputDirectory(), new ApplicationPackageParameters(
 				bundles,

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/AbstractBundleModuleTask.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/AbstractBundleModuleTask.java
@@ -187,7 +187,7 @@ public class AbstractBundleModuleTask extends AbstractDefinitionAwareSpaghettiTa
 		File outputDir = getOutputDirectory();
 		getLogger().info("Creating bundle in {}", outputDir);
 		TreeSet<String> dependentModuleNames = Sets.newTreeSet();
-		for (ModuleNode moduleNode : config.getDependentModules()) {
+		for (ModuleNode moduleNode : config.getAllDependentModules()) {
 			dependentModuleNames.add(moduleNode.getName());
 		}
 

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/AbstractBundleModuleTask.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/AbstractBundleModuleTask.java
@@ -187,7 +187,7 @@ public class AbstractBundleModuleTask extends AbstractDefinitionAwareSpaghettiTa
 		File outputDir = getOutputDirectory();
 		getLogger().info("Creating bundle in {}", outputDir);
 		TreeSet<String> dependentModuleNames = Sets.newTreeSet();
-		for (ModuleNode moduleNode : config.getAllDependentModules()) {
+		for (ModuleNode moduleNode : config.getDirectDependentModules()) {
 			dependentModuleNames.add(moduleNode.getName());
 		}
 

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/AbstractSpaghettiTask.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/AbstractSpaghettiTask.java
@@ -1,8 +1,6 @@
 package com.prezi.spaghetti.gradle.internal;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
-import com.prezi.spaghetti.bundle.ModuleBundle;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 import com.prezi.spaghetti.definition.ModuleConfiguration;
 import com.prezi.spaghetti.definition.ModuleConfigurationParser;
 import com.prezi.spaghetti.definition.ModuleDefinitionSource;
@@ -13,8 +11,6 @@ import org.gradle.api.tasks.InputFiles;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Set;
 
 public class AbstractSpaghettiTask extends ConventionTask {
 	private ConfigurableFileCollection dependentModules = getProject().files();
@@ -63,8 +59,8 @@ public class AbstractSpaghettiTask extends ConventionTask {
 		dependentModule(additionalDependentModules);
 	}
 
-	protected Set<ModuleBundle> lookupBundles() throws IOException {
-		return ModuleBundleLookup.lookup(getDependentModules());
+	protected ModuleBundleSet lookupBundles() throws IOException {
+		return ModuleBundleLookup.lookup(getProject(), getDependentModules());
 	}
 
 	public ModuleConfiguration readConfig(File definition) throws IOException {
@@ -78,22 +74,9 @@ public class AbstractSpaghettiTask extends ConventionTask {
 	}
 
 	private ModuleConfiguration readConfigInternal(ModuleDefinitionSource localDefinition) throws IOException {
-		Collection<ModuleDefinitionSource> sources = makeModuleSources(lookupBundles());
-		ModuleConfiguration config = ModuleConfigurationParser.parse(localDefinition, sources);
+		ModuleBundleSet bundles = lookupBundles();
+		ModuleConfiguration config = ModuleConfigurationParser.parse(localDefinition, bundles);
 		getLogger().info("Loaded configuration: {}", config);
 		return config;
-	}
-
-	private static Collection<ModuleDefinitionSource> makeModuleSources(Set<ModuleBundle> bundles) {
-		return Collections2.transform(bundles, new Function<ModuleBundle, ModuleDefinitionSource>() {
-			@Override
-			public ModuleDefinitionSource apply(ModuleBundle bundle) {
-				try {
-					return ModuleDefinitionSource.fromBundle(bundle);
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			}
-		});
 	}
 }

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/ModuleBundleLookup.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/ModuleBundleLookup.java
@@ -1,48 +1,88 @@
 package com.prezi.spaghetti.gradle.internal;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
-import com.prezi.spaghetti.bundle.ModuleBundle;
-import com.prezi.spaghetti.bundle.ModuleBundleFactory;
+import com.prezi.spaghetti.bundle.ModuleBundleLoader;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 public class ModuleBundleLookup {
 	private static final Logger logger = LoggerFactory.getLogger(ModuleBundleLookup.class);
 
-	public static Set<ModuleBundle> lookup(Iterable<File> dependencies) throws IOException {
+	public static ModuleBundleSet lookup(Project project, ConfigurableFileCollection dependencies) throws IOException {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Looking up modules:");
 			logger.debug("\tDependencies:\n\t\t{}", Joiner.on("\n\t\t").join(dependencies));
 		}
 
-		Set<ModuleBundle> bundles = Sets.newTreeSet();
-		for (File file : dependencies) {
-			ModuleBundle bundle = tryLoadBundle(file);
-			if (bundle != null) {
-				bundles.add(bundle);
-			}
+		Set<File> directBundles = Sets.newLinkedHashSet();
+		Set<File> transitiveBundles = Sets.newLinkedHashSet();
+
+		Set<Object> dependencyObjects = dependencies.getFrom();
+		for (Object from : dependencyObjects) {
+			addFiles(project, from, directBundles, transitiveBundles);
 		}
 
-		return bundles;
+		return ModuleBundleLoader.loadBundles(directBundles, transitiveBundles);
 	}
 
-	private static ModuleBundle tryLoadBundle(File file) throws IOException {
-		logger.debug("Trying to load module bundle from {}", file);
-		try {
-			ModuleBundle bundle = ModuleBundleFactory.load(file);
-			logger.info("Found module bundle {}", bundle.getName());
-			return bundle;
-		} catch (IOException ex) {
-			throw ex;
-		} catch (Exception ex) {
-			logger.debug("Not a module bundle: {}: {}", file, ex);
-			logger.trace("Exception", ex);
-			return null;
+	private static void addFiles(Project project, Object from, Set<File> directFiles, Set<File> transitiveFiles) throws IOException {
+		if (from == null) {
+			return;
+		}
+
+		if (from instanceof Configuration) {
+			Configuration config = (Configuration) from;
+			Set<ResolvedDependency> firstLevelDependencies = config.getResolvedConfiguration().getFirstLevelModuleDependencies();
+			addAllFilesFrom(firstLevelDependencies, directFiles);
+			addAllFilesFromChildren(firstLevelDependencies, transitiveFiles);
+		} else if (from instanceof Collection) {
+			for (Object child : ((Collection<?>) from)) {
+				addFiles(project, child, directFiles, transitiveFiles);
+			}
+		} else if (from.getClass().isArray()) {
+			for (int i = 0; i < Array.getLength(from); i++) {
+				addFiles(project, Array.get(from, i), directFiles, transitiveFiles);
+			}
+		} else if (from instanceof Callable) {
+			try {
+				addFiles(project, ((Callable) from).call(), directFiles, transitiveFiles);
+			} catch (Exception e) {
+				throw Throwables.propagate(e);
+			}
+		} else {
+			for (File file : project.files(from)) {
+				directFiles.add(file);
+			}
+		}
+	}
+
+	private static void addAllFilesFromChildren(Set<ResolvedDependency> dependencies, Set<File> files) throws IOException {
+		for (ResolvedDependency dependency : dependencies) {
+			addAllFilesFrom(dependency.getChildren(), files);
+			addAllFilesFromChildren(dependency.getChildren(), files);
+		}
+	}
+
+	private static void addAllFilesFrom(Set<ResolvedDependency> dependencies, Set<File> files) throws IOException {
+		for (ResolvedDependency dependency : dependencies) {
+			for (ResolvedArtifact artifact : dependency.getModuleArtifacts()) {
+				files.add(artifact.getFile());
+			}
 		}
 	}
 }

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/ModuleBundleLookup.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/ModuleBundleLookup.java
@@ -50,7 +50,7 @@ public class ModuleBundleLookup {
 			addAllFilesFrom(firstLevelDependencies, directFiles);
 			addAllFilesFromChildren(firstLevelDependencies, transitiveFiles);
 		} else if (from instanceof ConfigurableFileCollection) {
-			for (Object child : ((ConfigurableFileCollection) from)) {
+			for (Object child : ((ConfigurableFileCollection) from).getFrom()) {
 				addFiles(project, child, directFiles, transitiveFiles);
 			}
 		} else if (from instanceof FileCollection) {

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/ModuleBundleLoader.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/ModuleBundleLoader.java
@@ -1,0 +1,46 @@
+package com.prezi.spaghetti.bundle;
+
+import com.google.common.collect.Sets;
+import com.prezi.spaghetti.bundle.internal.DefaultModuleBundleSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+
+public class ModuleBundleLoader {
+	private  static final Logger logger = LoggerFactory.getLogger(ModuleBundleLoader.class);
+
+	public static ModuleBundleSet loadBundles(Collection<File> directBundleFiles, Collection<File> transitiveBundleFiles) throws IOException {
+		Set<ModuleBundle> directBundles = loadBundles(directBundleFiles);
+		Set<ModuleBundle> transitiveBundles = loadBundles(transitiveBundleFiles);
+
+		if (transitiveBundles.removeAll(directBundles)) {
+			logger.warn("Some module bundles appear both as direct and as transitive dependencies, treating them as direct dependencies");
+		}
+
+		return new DefaultModuleBundleSet(directBundles, transitiveBundles);
+	}
+
+	private static Set<ModuleBundle> loadBundles(Collection<File> bundleFiles) throws IOException {
+		Set<ModuleBundle> bundles = Sets.newLinkedHashSet();
+		for (File bundleFile : bundleFiles) {
+			logger.debug("Trying to load module bundle from {}", bundleFile);
+			try {
+				ModuleBundle bundle = ModuleBundleFactory.load(bundleFile);
+				logger.info("Found module bundle {}", bundle.getName());
+				if (bundles.add(bundle)) {
+					logger.warn("Bundle {} already loaded", bundle.getName());
+				}
+			} catch (IOException ex) {
+				throw ex;
+			} catch (Exception ex) {
+				logger.debug("Not a module bundle: {}: {}", bundleFile, ex);
+				logger.trace("Exception", ex);
+			}
+		}
+		return bundles;
+	}
+}

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/ModuleBundleLoader.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/ModuleBundleLoader.java
@@ -17,8 +17,10 @@ public class ModuleBundleLoader {
 		Set<ModuleBundle> directBundles = loadBundles(directBundleFiles);
 		Set<ModuleBundle> transitiveBundles = loadBundles(transitiveBundleFiles);
 
-		if (transitiveBundles.removeAll(directBundles)) {
-			logger.warn("Some module bundles appear both as direct and as transitive dependencies, treating them as direct dependencies");
+		Sets.SetView<ModuleBundle> sharedModules = Sets.intersection(directBundles, transitiveBundles);
+		if (!sharedModules.isEmpty()) {
+			logger.info("Some module bundles appear both as direct and as transitive dependencies, treating them as direct dependencies: {}", sharedModules);
+			transitiveBundles.removeAll(directBundles);
 		}
 
 		return new DefaultModuleBundleSet(directBundles, transitiveBundles);
@@ -31,8 +33,8 @@ public class ModuleBundleLoader {
 			try {
 				ModuleBundle bundle = ModuleBundleFactory.load(bundleFile);
 				logger.info("Found module bundle {}", bundle.getName());
-				if (bundles.add(bundle)) {
-					logger.warn("Bundle {} already loaded", bundle.getName());
+				if (!bundles.add(bundle)) {
+					logger.warn("Bundle {} loaded twice", bundle.getName());
 				}
 			} catch (IOException ex) {
 				throw ex;

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/ModuleBundleSet.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/ModuleBundleSet.java
@@ -1,0 +1,8 @@
+package com.prezi.spaghetti.bundle;
+
+import java.util.SortedSet;
+
+public interface ModuleBundleSet extends SortedSet<ModuleBundle> {
+	SortedSet<ModuleBundle> getDirectBundles();
+	SortedSet<ModuleBundle> getTransitiveBundles();
+}

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/internal/DefaultModuleBundleSet.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/bundle/internal/DefaultModuleBundleSet.java
@@ -1,0 +1,44 @@
+package com.prezi.spaghetti.bundle.internal;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ForwardingSortedSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.prezi.spaghetti.bundle.ModuleBundle;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
+
+public class DefaultModuleBundleSet extends ForwardingSortedSet<ModuleBundle> implements ModuleBundleSet {
+	private final SortedSet<ModuleBundle> directBundles;
+	private final SortedSet<ModuleBundle> transitiveBundles;
+	private final SortedSet<ModuleBundle> allBundles;
+
+	public DefaultModuleBundleSet(Set<ModuleBundle> directBundles, Set<ModuleBundle> transitiveBundles) {
+		Preconditions.checkArgument(Collections.disjoint(
+						Preconditions.checkNotNull(directBundles, "directBundles"),
+						Preconditions.checkNotNull(transitiveBundles, "transitiveBundles")
+				),
+				"Some bundles are both direct and transitive, direct bundles: " + directBundles
+						+ ", transitive bundles: " + transitiveBundles);
+		this.directBundles = ImmutableSortedSet.copyOf(directBundles);
+		this.transitiveBundles = ImmutableSortedSet.copyOf(transitiveBundles);
+		this.allBundles = ImmutableSortedSet.<ModuleBundle>naturalOrder().addAll(directBundles).addAll(transitiveBundles).build();
+	}
+
+	@Override
+	protected SortedSet<ModuleBundle> delegate() {
+		return allBundles;
+	}
+
+	@Override
+	public SortedSet<ModuleBundle> getDirectBundles() {
+		return directBundles;
+	}
+
+	@Override
+	public SortedSet<ModuleBundle> getTransitiveBundles() {
+		return transitiveBundles;
+	}
+}

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/ModuleConfiguration.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/ModuleConfiguration.java
@@ -10,13 +10,31 @@ import java.util.SortedSet;
 public interface ModuleConfiguration {
 	/**
 	 * Returns the local module.
+	 *
+	 * @return the local module.
 	 */
 	ModuleNode getLocalModule();
 
 	/**
-	 * Returns dependencies of the local module.
+	 * Returns direct dependencies of the local module.
+	 *
+	 * @return direct dependencies of the local module.
 	 */
-	SortedSet<ModuleNode> getDependentModules();
+	SortedSet<ModuleNode> getDirectDependentModules();
+
+	/**
+	 * Returns transitive dependencies of the local module.
+	 *
+	 * @return transitive dependencies of the local module.
+	 */
+	SortedSet<ModuleNode> getTransitiveDependentModules();
+
+	/**
+	 * Returns all dependencies of the local module, including both direct and transitive dependencies.
+	 *
+	 * @return all dependencies of the local module.
+	 */
+	SortedSet<ModuleNode> getAllDependentModules();
 
 	/**
 	 * Returns all modules in the configuration, including the local module and its dependencies.

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/ModuleConfigurationParser.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/ModuleConfigurationParser.java
@@ -1,5 +1,7 @@
 package com.prezi.spaghetti.definition;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.prezi.spaghetti.ast.ModuleNode;
@@ -8,8 +10,11 @@ import com.prezi.spaghetti.ast.internal.parser.MissingTypeResolver;
 import com.prezi.spaghetti.ast.internal.parser.ModuleParser;
 import com.prezi.spaghetti.ast.internal.parser.ModuleTypeResolver;
 import com.prezi.spaghetti.ast.internal.parser.TypeResolver;
+import com.prezi.spaghetti.bundle.ModuleBundle;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 import com.prezi.spaghetti.definition.internal.DefaultModuleConfiguration;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -21,31 +26,59 @@ public final class ModuleConfigurationParser {
 	/**
 	 * Parses module definitions for a module.
 	 *
-	 * @param localModuleSource      the source of the local module.
-	 * @param dependentModuleSources the sources of dependent modules.
-	 * @return the loaded module configuration.
+	 * @param localModuleSource the source of the local module.
+	 * @param dependencies      the loaded bundles.
+	 * @return the parsed module configuration.
 	 */
-	public static ModuleConfiguration parse(ModuleDefinitionSource localModuleSource, Collection<ModuleDefinitionSource> dependentModuleSources) {
+	public static ModuleConfiguration parse(ModuleDefinitionSource localModuleSource, ModuleBundleSet dependencies) {
+		Collection<ModuleDefinitionSource> directSources = makeModuleSources(dependencies.getDirectBundles());
+		Collection<ModuleDefinitionSource> transitiveSources = makeModuleSources(dependencies.getTransitiveBundles());
+		return parse(localModuleSource, directSources, transitiveSources);
+	}
+
+	private static Collection<ModuleDefinitionSource> makeModuleSources(Set<ModuleBundle> bundles) {
+		return Collections2.transform(bundles, new Function<ModuleBundle, ModuleDefinitionSource>() {
+			@Override
+			public ModuleDefinitionSource apply(ModuleBundle bundle) {
+				try {
+					return ModuleDefinitionSource.fromBundle(bundle);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Parses module definitions for a module.
+	 *
+	 * @param localModuleSource       the source of the local module.
+	 * @param directModuleSources     the sources of directly dependent modules.
+	 * @param transitiveModuleSources the sources of transitively dependent modules.
+	 * @return the parsed module configuration.
+	 */
+	public static ModuleConfiguration parse(ModuleDefinitionSource localModuleSource, Collection<ModuleDefinitionSource> directModuleSources, Collection<ModuleDefinitionSource> transitiveModuleSources) {
 		Set<String> parsedModules = Sets.newLinkedHashSet();
-		DefaultModuleConfiguration configNode = new DefaultModuleConfiguration();
 
-		Collection<ModuleParser> dependentParsers = createParsersFor(dependentModuleSources);
 		Collection<ModuleParser> localParsers = createParsersFor(Collections.singleton(localModuleSource));
+		Collection<ModuleParser> directParsers = createParsersFor(directModuleSources);
+		Collection<ModuleParser> transitiveParsers = createParsersFor(transitiveModuleSources);
 
-		TypeResolver resolver = createResolverFor(Iterables.concat(localParsers, dependentParsers));
+		TypeResolver resolver = createResolverFor(Iterables.concat(localParsers, directParsers, transitiveParsers));
 
 		Set<ModuleNode> localModules = Sets.newLinkedHashSet();
-		parsedModules(resolver, dependentParsers, configNode.getDependentModules(), parsedModules);
-		parsedModules(resolver, localParsers, localModules, parsedModules);
+		Set<ModuleNode> directDependentModules = Sets.newLinkedHashSet();
+		Set<ModuleNode> transitiveDependentModules = Sets.newLinkedHashSet();
+		parseModules(resolver, transitiveParsers, transitiveDependentModules, parsedModules);
+		parseModules(resolver, directParsers, directDependentModules, parsedModules);
+		parseModules(resolver, localParsers, localModules, parsedModules);
 		if (localModules.isEmpty()) {
 			throw new IllegalStateException("No local module found");
 		}
 		if (localModules.size() > 1) {
 			throw new IllegalStateException("More than one local module found: " + localModules);
 		}
-		configNode.setLocalModule(Iterables.getOnlyElement(localModules));
-
-		return configNode;
+		return new DefaultModuleConfiguration(Iterables.getOnlyElement(localModules), directDependentModules, transitiveDependentModules);
 	}
 
 	private static Collection<ModuleParser> createParsersFor(Collection<ModuleDefinitionSource> sources) {
@@ -64,7 +97,7 @@ public final class ModuleConfigurationParser {
 		return resolver;
 	}
 
-	private static void parsedModules(TypeResolver resolver, Collection<ModuleParser> parsers, Collection<ModuleNode> moduleNodes, Set<String> allModuleNames) {
+	private static void parseModules(TypeResolver resolver, Collection<ModuleParser> parsers, Collection<ModuleNode> moduleNodes, Set<String> allModuleNames) {
 		for (ModuleParser parser : parsers) {
 			ModuleNode module = parser.parse(resolver);
 			if (allModuleNames.contains(module.getName())) {

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/ModuleConfigurationParser.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/ModuleConfigurationParser.java
@@ -1,6 +1,7 @@
 package com.prezi.spaghetti.definition;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -43,7 +44,7 @@ public final class ModuleConfigurationParser {
 				try {
 					return ModuleDefinitionSource.fromBundle(bundle);
 				} catch (IOException e) {
-					throw new RuntimeException(e);
+					throw Throwables.propagate(e);
 				}
 			}
 		});

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/internal/DefaultModuleConfiguration.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/internal/DefaultModuleConfiguration.java
@@ -1,21 +1,41 @@
 package com.prezi.spaghetti.definition.internal;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedSet;
 import com.prezi.spaghetti.ast.ModuleNode;
 import com.prezi.spaghetti.definition.ModuleConfiguration;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeSet;
 
 public class DefaultModuleConfiguration implements ModuleConfiguration {
-	private ModuleNode localModule;
-	private final SortedSet<ModuleNode> dependentModules = new TreeSet<ModuleNode>();
+	private final ModuleNode localModule;
+	private final SortedSet<ModuleNode> directDependentModules;
+	private final SortedSet<ModuleNode> transitiveDependentModules;
+	private final SortedSet<ModuleNode> allDependentModules;
+	private final SortedSet<ModuleNode> allModules;
 
-	@Override
-	public SortedSet<ModuleNode> getAllModules() {
-		return Sets.newTreeSet(Iterables.concat(Collections.singleton(localModule), dependentModules));
+	public DefaultModuleConfiguration(ModuleNode localModule, Set<ModuleNode> directDependentModules, Set<ModuleNode> transitiveDependentModules) {
+		Preconditions.checkNotNull(localModule, "localModule");
+		Preconditions.checkArgument(Collections.disjoint(
+						Preconditions.checkNotNull(directDependentModules, "directDependentModules"),
+						Preconditions.checkNotNull(transitiveDependentModules, "transitiveDependentModules")
+				),
+				"Some modules appear both to be direct and transitive dependencies, direct dependencies: " + directDependentModules
+						+ ", transitive dependencies: " + transitiveDependentModules);
+		Preconditions.checkArgument(!directDependentModules.contains(localModule),
+				"Local module is also one of the direct dependencies, local module: " + localModule
+						+ ", direct dependencies: " + directDependentModules);
+		Preconditions.checkArgument(!transitiveDependentModules.contains(localModule),
+				"Local module is also one of the transitive dependencies, local module: " + localModule
+						+ ", transitive dependencies: " + transitiveDependentModules);
+
+		this.localModule = localModule;
+		this.directDependentModules = ImmutableSortedSet.copyOf(directDependentModules);
+		this.transitiveDependentModules = ImmutableSortedSet.copyOf(transitiveDependentModules);
+		this.allDependentModules = ImmutableSortedSet.<ModuleNode>naturalOrder().addAll(directDependentModules).addAll(transitiveDependentModules).build();
+		this.allModules = ImmutableSortedSet.<ModuleNode>naturalOrder().add(localModule).addAll(directDependentModules).addAll(transitiveDependentModules).build();
 	}
 
 	@Override
@@ -23,12 +43,23 @@ public class DefaultModuleConfiguration implements ModuleConfiguration {
 		return localModule;
 	}
 
-	public void setLocalModule(ModuleNode localModule) {
-		this.localModule = localModule;
+	@Override
+	public SortedSet<ModuleNode> getDirectDependentModules() {
+		return directDependentModules;
 	}
 
 	@Override
-	public SortedSet<ModuleNode> getDependentModules() {
-		return dependentModules;
+	public SortedSet<ModuleNode> getTransitiveDependentModules() {
+		return transitiveDependentModules;
+	}
+
+	@Override
+	public SortedSet<ModuleNode> getAllDependentModules() {
+		return allDependentModules;
+	}
+
+	@Override
+	public SortedSet<ModuleNode> getAllModules() {
+		return allModules;
 	}
 }

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/internal/DefaultModuleConfiguration.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/definition/internal/DefaultModuleConfiguration.java
@@ -62,4 +62,13 @@ public class DefaultModuleConfiguration implements ModuleConfiguration {
 	public SortedSet<ModuleNode> getAllModules() {
 		return allModules;
 	}
+
+	@Override
+	public String toString() {
+		return "DefaultModuleConfiguration("
+				+ "local module: " + localModule
+				+ ", direct dependencies: " + directDependentModules
+				+ ", transitive dependencies: " + transitiveDependentModules
+				+ ")";
+	}
 }

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/packaging/ApplicationPackageParameters.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/packaging/ApplicationPackageParameters.java
@@ -1,20 +1,18 @@
 package com.prezi.spaghetti.packaging;
 
-import com.prezi.spaghetti.bundle.ModuleBundle;
-
-import java.util.Set;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 
 public class ApplicationPackageParameters {
 	public static final String DEFAULT_APPLICATION_NAME = "application.js";
 
-	public final Set<ModuleBundle> bundles;
+	public final ModuleBundleSet bundles;
 	public final String applicationName;
 	public final String mainModule;
 	public final boolean execute;
 	public final Iterable<String> prefixes;
 	public final Iterable<String> suffixes;
 
-	public ApplicationPackageParameters(Set<ModuleBundle> bundles, String applicationName, String mainModule, boolean execute, Iterable<String> prefixes, Iterable<String> suffixes) {
+	public ApplicationPackageParameters(ModuleBundleSet bundles, String applicationName, String mainModule, boolean execute, Iterable<String> prefixes, Iterable<String> suffixes) {
 		this.bundles = bundles;
 		this.applicationName = applicationName;
 		this.mainModule = mainModule;

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/bundle/internal/DefaultModuleBundleSetTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/bundle/internal/DefaultModuleBundleSetTest.groovy
@@ -1,0 +1,51 @@
+package com.prezi.spaghetti.bundle.internal
+
+import com.prezi.spaghetti.bundle.ModuleBundle
+import spock.lang.Specification
+
+class DefaultModuleBundleSetTest extends Specification {
+	def "empty"() {
+		def set = new DefaultModuleBundleSet([] as Set, [] as Set)
+
+		expect:
+		set == [] as Set
+		set.isEmpty()
+		set.size() == 0
+		set.directBundles == [] as Set
+		set.transitiveBundles == [] as Set
+	}
+
+	def "mixed"() {
+		def direct1 = createBundle("direct1")
+		def direct2 = createBundle("direct2")
+		def transitive1 = createBundle("transitive1")
+		def transitive2 = createBundle("transitive2")
+
+		def set = new DefaultModuleBundleSet([direct1, direct2] as Set, [transitive1, transitive2] as Set)
+
+		expect:
+		set == [direct1, direct2, transitive1, transitive2] as Set
+		!set.isEmpty()
+		set.size() == 4
+		set.directBundles == [direct1, direct2] as Set
+		set.transitiveBundles == [transitive1, transitive2] as Set
+	}
+
+	def "not disjoint"() {
+		def bundle = createBundle("bundle")
+		when:
+		new DefaultModuleBundleSet([bundle] as Set, [bundle] as Set)
+
+		then:
+		thrown IllegalArgumentException
+	}
+
+	ModuleBundle createBundle(String name) {
+		return Mock(ModuleBundle) {
+			it.name >> name
+			it.compareTo(_) >> { ModuleBundle other ->
+				name.compareTo(other.name)
+			}
+		}
+	}
+}

--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeHeaderGenerator.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeHeaderGenerator.groovy
@@ -22,7 +22,7 @@ class HaxeHeaderGenerator extends AbstractHeaderGenerator {
 		generateModuleInitializer(config.localModule, outputDirectory, header)
 		generateModuleStaticProxy(config.localModule, outputDirectory, header)
 		generateModuleTypes(config.localModule, outputDirectory, header)
-		config.dependentModules.each { dependentModule ->
+		config.allDependentModules.each { dependentModule ->
 			generateModuleTypes(dependentModule, outputDirectory, header)
 			generateModuleAccessor(dependentModule, outputDirectory, header)
 		}

--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeHeaderGenerator.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/HaxeHeaderGenerator.groovy
@@ -24,6 +24,8 @@ class HaxeHeaderGenerator extends AbstractHeaderGenerator {
 		generateModuleTypes(config.localModule, outputDirectory, header)
 		config.allDependentModules.each { dependentModule ->
 			generateModuleTypes(dependentModule, outputDirectory, header)
+		}
+		config.directDependentModules.each { dependentModule ->
 			generateModuleAccessor(dependentModule, outputDirectory, header)
 		}
 	}

--- a/spaghetti-kotlin-support/src/main/groovy/com/prezi/spaghetti/kotlin/KotlinHeaderGenerator.groovy
+++ b/spaghetti-kotlin-support/src/main/groovy/com/prezi/spaghetti/kotlin/KotlinHeaderGenerator.groovy
@@ -23,7 +23,7 @@ class KotlinHeaderGenerator extends AbstractHeaderGenerator {
 		generateModuleInitializer(config.localModule, outputDirectory, header)
 		generateModuleStaticProxy(config.localModule, outputDirectory, header)
 		generateModuleTypes(config.localModule, outputDirectory, header)
-		config.dependentModules.each { dependentModule ->
+		config.allDependentModules.each { dependentModule ->
 			generateModuleTypes(dependentModule, outputDirectory, header)
 			generateModuleAccessor(dependentModule, outputDirectory, header)
 		}

--- a/spaghetti-kotlin-support/src/main/groovy/com/prezi/spaghetti/kotlin/KotlinHeaderGenerator.groovy
+++ b/spaghetti-kotlin-support/src/main/groovy/com/prezi/spaghetti/kotlin/KotlinHeaderGenerator.groovy
@@ -25,6 +25,8 @@ class KotlinHeaderGenerator extends AbstractHeaderGenerator {
 		generateModuleTypes(config.localModule, outputDirectory, header)
 		config.allDependentModules.each { dependentModule ->
 			generateModuleTypes(dependentModule, outputDirectory, header)
+		}
+		config.directDependentModules.each { dependentModule ->
 			generateModuleAccessor(dependentModule, outputDirectory, header)
 		}
 	}

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
@@ -21,7 +21,7 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 		def header = params.header
 		copySpaghettiClass(outputDirectory)
 		generateLocalModule(config.localModule, outputDirectory, header)
-		config.dependentModules.each { dependentModule ->
+		config.allDependentModules.each { dependentModule ->
 			generateDependentModule(dependentModule, outputDirectory, header)
 		}
 	}

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
@@ -21,8 +21,11 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 		def header = params.header
 		copySpaghettiClass(outputDirectory)
 		generateLocalModule(config.localModule, outputDirectory, header)
-		config.allDependentModules.each { dependentModule ->
-			generateDependentModule(dependentModule, outputDirectory, header)
+		config.directDependentModules.each { dependentModule ->
+			generateDependentModule(dependentModule, outputDirectory, header, true)
+		}
+		config.transitiveDependentModules.each { dependentModule ->
+			generateDependentModule(dependentModule, outputDirectory, header, false)
 		}
 	}
 
@@ -45,9 +48,11 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 		TypeScriptUtils.createSourceFile(header, module, module.alias, outputDirectory, contents)
 	}
 
-	private static void generateDependentModule(ModuleNode module, File outputDirectory, String header) {
+	private static void generateDependentModule(ModuleNode module, File outputDirectory, String header, boolean generateAccessor) {
 		def contents = "declare var ${SPAGHETTI_CLASS}:any;\n"
-		contents += new TypeScriptModuleAccessorGeneratorVisitor(module).visit(module)
+		if (generateAccessor) {
+			contents += new TypeScriptModuleAccessorGeneratorVisitor(module).visit(module)
+		}
 		contents += new TypeScriptDefinitionIteratorVisitor().visit(module)
 		TypeScriptUtils.createSourceFile(header, module, module.alias, outputDirectory, contents)
 	}

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/AbstractCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/AbstractCommand.java
@@ -1,10 +1,14 @@
 package com.prezi.spaghetti.cli.commands;
 
 import io.airlift.command.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
 
 public abstract class AbstractCommand implements Callable<Integer> {
+	protected static final Logger logger = LoggerFactory.getLogger(AbstractCommand.class);
+
 	@Option(name = {"-v", "--verbose"},
 			description = "Verbose mode")
 	private boolean verbose;

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/AbstractDefinitionAwareCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/AbstractDefinitionAwareCommand.java
@@ -1,7 +1,6 @@
 package com.prezi.spaghetti.cli.commands;
 
-import com.google.common.collect.Sets;
-import com.prezi.spaghetti.bundle.ModuleBundle;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 import com.prezi.spaghetti.definition.ModuleConfiguration;
 import com.prezi.spaghetti.definition.ModuleConfigurationParser;
 import com.prezi.spaghetti.definition.ModuleDefinitionSource;
@@ -9,7 +8,6 @@ import io.airlift.command.Option;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 
 public abstract class AbstractDefinitionAwareCommand extends AbstractSpaghettiCommand {
 	@Option(name = {"-m", "--definition"},
@@ -19,16 +17,8 @@ public abstract class AbstractDefinitionAwareCommand extends AbstractSpaghettiCo
 
 	protected ModuleConfiguration parseConfig() throws IOException {
 		ModuleDefinitionSource localSource  = parseDefinition(definition);
-		Collection<ModuleDefinitionSource> dependentSources = parseDefinitionSources(dependencyPath);
-		return ModuleConfigurationParser.parse(localSource, dependentSources);
-	}
-
-	private static Collection<ModuleDefinitionSource> parseDefinitionSources(String path) throws IOException {
-		Collection<ModuleDefinitionSource> sources = Sets.newLinkedHashSet();
-		for (ModuleBundle bundle : parseBundles(path)) {
-			sources.add(ModuleDefinitionSource.fromBundle(bundle));
-		}
-		return sources;
+		ModuleBundleSet bundles = lookupBundles();
+		return ModuleConfigurationParser.parse(localSource, bundles);
 	}
 
 	private static ModuleDefinitionSource parseDefinition(File file) throws IOException {

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/AbstractSpaghettiCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/AbstractSpaghettiCommand.java
@@ -1,29 +1,24 @@
 package com.prezi.spaghetti.cli.commands;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Sets;
-import com.prezi.spaghetti.bundle.ModuleBundle;
-import com.prezi.spaghetti.bundle.ModuleBundleFactory;
+import com.google.common.collect.Lists;
+import com.prezi.spaghetti.bundle.ModuleBundleLoader;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 import io.airlift.command.Option;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 
 public abstract class AbstractSpaghettiCommand extends AbstractCommand {
-	@Option(name = {"-d", "--dependency-path"},
-			description = "List of dependent module bundles separated by colon (':')")
-	protected String dependencyPath;
+	@Option(name = {"-d", "--dependent-module", "--direct-dependent-module"},
+			description = "Specifies a (directly) dependent module bundle file")
+	protected List<File> directDependencies = Lists.newArrayList();
 
-	protected static Set<ModuleBundle> parseBundles(String path) throws IOException {
-		Set<ModuleBundle> bundles = Sets.newLinkedHashSet();
-		if (!Strings.isNullOrEmpty(path)) {
-			for (String bundlePath : path.split(":")) {
-				File bundleFile = new File(bundlePath);
-				ModuleBundle bundle = ModuleBundleFactory.load(bundleFile);
-				bundles.add(bundle);
-			}
-		}
-		return bundles;
+	@Option(name = {"-t", "--transitive-dependent-module"},
+			description = "Specifies a (transitively) dependent module bundle file")
+	protected List<File> transitiveDependencies = Lists.newArrayList();
+
+	protected ModuleBundleSet lookupBundles() throws IOException {
+		return ModuleBundleLoader.loadBundles(directDependencies, transitiveDependencies);
 	}
 }

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
@@ -100,7 +100,7 @@ public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 		String processedJavaScript = InternalGeneratorUtils.bundleJavaScript(javaScriptBundleProcessor.processModuleJavaScript(processorParams, javaScript));
 
 		SortedSet<String> dependentModules = Sets.newTreeSet();
-		for (ModuleNode dependentModule : config.getAllDependentModules()) {
+		for (ModuleNode dependentModule : config.getDirectDependentModules()) {
 			dependentModules.add(dependentModule.getName());
 		}
 

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
@@ -100,7 +100,7 @@ public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 		String processedJavaScript = InternalGeneratorUtils.bundleJavaScript(javaScriptBundleProcessor.processModuleJavaScript(processorParams, javaScript));
 
 		SortedSet<String> dependentModules = Sets.newTreeSet();
-		for (ModuleNode dependentModule : config.getDependentModules()) {
+		for (ModuleNode dependentModule : config.getAllDependentModules()) {
 			dependentModules.add(dependentModule.getName());
 		}
 

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/PackageApplicationCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/PackageApplicationCommand.java
@@ -1,6 +1,6 @@
 package com.prezi.spaghetti.cli.commands;
 
-import com.prezi.spaghetti.bundle.ModuleBundle;
+import com.prezi.spaghetti.bundle.ModuleBundleSet;
 import com.prezi.spaghetti.packaging.ApplicationPackageParameters;
 import com.prezi.spaghetti.packaging.ApplicationType;
 import com.prezi.spaghetti.structure.OutputType;
@@ -9,7 +9,6 @@ import io.airlift.command.Option;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.Set;
 
 @Command(name = "package", description = "Package an application")
 public class PackageApplicationCommand extends AbstractSpaghettiCommand {
@@ -44,7 +43,7 @@ public class PackageApplicationCommand extends AbstractSpaghettiCommand {
 		OutputType type = OutputType.fromString(this.type, output);
 		ApplicationType wrapper = ApplicationType.fromString(this.wrapper);
 
-		Set<ModuleBundle> bundles = parseBundles(dependencyPath);
+		ModuleBundleSet bundles = lookupBundles();
 
 		ApplicationPackageParameters params = new ApplicationPackageParameters(
 				bundles,


### PR DESCRIPTION
It seemed like a good idea at the time (#141) to allow access to transitive modules as well. However, it causes further problems. Here's why:

We need to record the names of each module in the final, packaged JavaScript that the code inside has access to, so that RequireJS/Node JS can load them. If we allow access to transitive dependencies, the names of those modules need to be wired in as well. Like so:

```js
define(["my.direct.dependency", "my.transitive.dependency"], function() { /* ... */ });
```

This has some unwanted consequences: even if my module's code does not access the `my.transitive.dependency` module at all, RequireJS will still try to load it, because it's listed as a dependency. However, if `my.direct.dependency` is changed, and it doesn't depend on `my.transitive.dependency`, a `PackageApplication` task depending only on my module will not know about `my.transitive.dependency`, and will not package that module into the application, leading to a runtime error.

In other words, the problem is that one can break every dependent of module A if they remove or rename one of module A's dependencies (module B), even if nobody ever used a single API from module B. This breaks Spaghetti’s promise that “as long as your API doesn’t change (break), your dependent modules should continue to work during runtime.”

Once you delete module B, the only way to make things work again is to repackage every module that depends on module A, either directly or transitively. This is hard to debug, error prone and doesn’t scale well.

This pull-request is about re-introducing blocking access to transitive modules. After this change we are going back to how things used to work in Spaghetti 2.0:

* module objects are only generated for direct dependencies
* types, enums and constants are generated for both direct and transitive dependencies