### PR TITLE
Test tasks should run with a test configuration

### DIFF
--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
@@ -73,7 +73,7 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 		spaghettiExtension.getSources().getByName("main").withType(SpaghettiGeneratedSourceSet.class).all(new Action<SpaghettiGeneratedSourceSet>() {
 			@Override
 			public void execute(final SpaghettiGeneratedSourceSet spaghettiGeneratedSourceSet) {
-				addSpaghettiSourceSet(project, haxeExtension, spaghettiGeneratedSourceSet, HaxeBinaryBase.class, "spaghetti");
+				addSpaghettiSourceSet(project, haxeExtension, spaghettiGeneratedSourceSet, HaxeBinary.class, "spaghetti");
 			}
 		});
 
@@ -81,7 +81,7 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 		spaghettiExtension.getSources().getByName("test").withType(SpaghettiGeneratedSourceSet.class).all(new Action<SpaghettiGeneratedSourceSet>() {
 			@Override
 			public void execute(final SpaghettiGeneratedSourceSet spaghettiGeneratedSourceSet) {
-				addSpaghettiSourceSet(project, haxeExtension, spaghettiGeneratedSourceSet, HaxeBinaryBase.class, "spaghetti");
+				addSpaghettiSourceSet(project, haxeExtension, spaghettiGeneratedSourceSet, HaxeTestBinary.class, "spaghetti");
 			}
 		});
 
@@ -109,7 +109,7 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 			@Override
 			public void execute(final HaxeSpaghettiModule moduleBinary) {
 				HaxeBinaryBase<?> binary = moduleBinary.getOriginal();
-				if (binary instanceof HaxeTestBinary) {
+				if (moduleBinary.isUsedForTesting() && binary instanceof HaxeTestBinary) {
 					HaxeTestBinary testBinary = (HaxeTestBinary) binary;
 					final PackageApplication appTask = createTestApplication(moduleBinary, testBinary);
 

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/GenerateHeaders.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/GenerateHeaders.java
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Callable;
 
 public class GenerateHeaders extends AbstractDefinitionAwareSpaghettiTask {
 	private File outputDirectory;
@@ -28,16 +27,6 @@ public class GenerateHeaders extends AbstractDefinitionAwareSpaghettiTask {
 
 	public void outputDirectory(Object directory) {
 		setOutputDirectory(directory);
-	}
-
-	public GenerateHeaders() {
-		this.getConventionMapping().map("outputDirectory", new Callable<File>() {
-			@Override
-			public File call() throws Exception {
-				return new File(getProject().getBuildDir(), "spaghetti/generated-headers");
-			}
-
-		});
 	}
 
 	@TaskAction

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/SpaghettiExtension.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/internal/SpaghettiExtension.java
@@ -17,14 +17,18 @@ public class SpaghettiExtension {
 
 	private String language;
 	private Configuration configuration;
+	private Configuration testConfiguration;
 	private Configuration obfuscatedConfiguration;
+	private Configuration testObfuscatedConfiguration;
 	private String sourceBaseUrl;
 
-	public SpaghettiExtension(final Project project, Instantiator instantiator, Configuration defaultConfiguration, Configuration defaultObfuscatedConfiguration) {
+	public SpaghettiExtension(final Project project, Instantiator instantiator, Configuration defaultConfiguration, Configuration defaultTestConfiguration, Configuration defaultObfuscatedConfiguration, Configuration defaultTestObfuscatedConfiguration) {
 		this.sources = instantiator.newInstance(DefaultProjectSourceSet.class, instantiator);
 		this.binaries = instantiator.newInstance(DefaultBinaryContainer.class, instantiator);
 		this.configuration = defaultConfiguration;
 		this.obfuscatedConfiguration = defaultObfuscatedConfiguration;
+		this.testConfiguration = defaultTestConfiguration;
+		this.testObfuscatedConfiguration = defaultTestObfuscatedConfiguration;
 
 		binaries.withType(BinaryInternal.class).all(new Action<BinaryInternal>() {
 			public void execute(BinaryInternal binary) {
@@ -76,6 +80,18 @@ public class SpaghettiExtension {
 		setConfiguration(configuration);
 	}
 
+	public Configuration getTestConfiguration() {
+		return testConfiguration;
+	}
+
+	public void setTestConfiguration(Configuration testConfiguration) {
+		this.testConfiguration = testConfiguration;
+	}
+
+	public void testConfiguration(Configuration testConfiguration) {
+		setTestConfiguration(testConfiguration);
+	}
+
 	public Configuration getObfuscatedConfiguration() {
 		return obfuscatedConfiguration;
 	}
@@ -86,6 +102,18 @@ public class SpaghettiExtension {
 
 	public void obfuscatedConfiguration(Configuration obfuscatedConfiguration) {
 		setObfuscatedConfiguration(obfuscatedConfiguration);
+	}
+
+	public Configuration getTestObfuscatedConfiguration() {
+		return testObfuscatedConfiguration;
+	}
+
+	public void setTestObfuscatedConfiguration(Configuration testObfuscatedConfiguration) {
+		this.testObfuscatedConfiguration = testObfuscatedConfiguration;
+	}
+
+	public void testObfuscatedConfiguration(Configuration testObfuscatedConfiguration) {
+		setTestObfuscatedConfiguration(testObfuscatedConfiguration);
 	}
 
 	public String getSourceBaseUrl() {

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/SpaghettiTypeScriptPlugin.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/SpaghettiTypeScriptPlugin.java
@@ -61,7 +61,7 @@ public class SpaghettiTypeScriptPlugin implements Plugin<Project> {
 		spaghettiExtension.getSources().getByName("main").withType(SpaghettiGeneratedSourceSet.class).all(new Action<SpaghettiGeneratedSourceSet>() {
 			@Override
 			public void execute(final SpaghettiGeneratedSourceSet spaghettiGeneratedSourceSet) {
-				addSpaghettiSourceSet(project, spaghettiGeneratedSourceSet, TypeScriptBinaryBase.class, "spaghetti");
+				addSpaghettiSourceSet(project, spaghettiGeneratedSourceSet, TypeScriptBinary.class, "spaghetti");
 			}
 		});
 

--- a/gradle-spaghetti-typescript-plugin/src/test/groovy/com/prezi/spaghetti/typescript/gradle/SpaghettiTypeScriptPluginTest.groovy
+++ b/gradle-spaghetti-typescript-plugin/src/test/groovy/com/prezi/spaghetti/typescript/gradle/SpaghettiTypeScriptPluginTest.groovy
@@ -20,6 +20,7 @@ class SpaghettiTypeScriptPluginTest extends Specification {
 				"compileTestJs",
 				"generateHeaders",
 				"generateStubs",
+				"generateTestHeaders",
 				"js",
 				"jsModule",
 				"obfuscateJsModule",


### PR DESCRIPTION
So there should be a `testModules` configuration (and a symmetric `testModulesObf`), where the user can add test Spaghetti dependencies.