### PR TITLE
Munit node

### DIFF
--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
@@ -1,0 +1,64 @@
+package com.prezi.spaghetti.haxe.gradle;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import sun.net.www.protocol.file.FileURLConnection;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class NodeTestWithSpaghetti extends MUnitWithSpaghetti {
+
+	@Override
+	protected void prepareEnvironment(File workDir) throws IOException {
+		copyCompiledTest(workDir);
+		URL url = this.getClass().getResource("/munit_node_resources");
+		copyResourcesRecursively(url, workDir);
+	}
+
+	public void copyResourcesRecursively(URL originUrl, File destination) throws IOException {
+		URLConnection urlConnection = originUrl.openConnection();
+		if (urlConnection instanceof JarURLConnection) {
+			copyJarResourcesRecursively(destination, (JarURLConnection) urlConnection);
+		} else if (urlConnection instanceof FileURLConnection) {
+			FileUtils.copyDirectory(new File(originUrl.getPath()), destination);
+		} else {
+			throw new RuntimeException("URLConnection[" + urlConnection.getClass().getSimpleName() +
+					"] is not a recognized/implemented connection type.");
+		}
+	}
+
+	public void copyJarResourcesRecursively(File destination, JarURLConnection jarConnection ) throws IOException {
+		JarFile jarFile = jarConnection.getJarFile();
+		for (JarEntry entry : Collections.list(jarFile.entries())) {
+			if (entry.getName().startsWith(jarConnection.getEntryName())) {
+				String fileName = StringUtils.removeStart(entry.getName(), jarConnection.getEntryName());
+				if (!entry.isDirectory()) {
+					InputStream entryInputStream = null;
+					try {
+						entryInputStream = jarFile.getInputStream(entry);
+						IOUtils.copy(entryInputStream, new FileOutputStream(new File(destination, fileName)));
+					} finally {
+						IOUtils.closeQuietly(entryInputStream);
+					}
+				} else {
+					FileUtils.forceMkdir(new File(destination, fileName));
+				}
+			}
+		}
+	}
+}

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.internal.ExecAction;
 import org.gradle.process.internal.ExecActionFactory;
 import sun.net.www.protocol.file.FileURLConnection;
@@ -54,10 +55,18 @@ public class NodeTestWithSpaghetti extends MUnitWithSpaghetti {
 	protected void prepareEnvironment(File workDir) throws IOException {
 		copyCompiledTest(workDir);
 		setupRunner(workDir);
-		run(workDir);
+		//run(workDir);
 	}
 
-	private void run(File workDir) {
+    @TaskAction
+    @Override
+    public void munit() throws IOException, InterruptedException {
+        File workDir = getWorkingDirectory();
+        FileUtils.deleteDirectory(workDir);
+        FileUtils.forceMkdir(workDir);
+
+        prepareEnvironment(workDir);
+
 		File munitNodeRunner = new File(workDir, "munit_node_runner.js");
 		munitNodeRunner.setExecutable(true);
 		ExecAction exec = execActionFactory.newExecAction();

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
@@ -112,4 +112,9 @@ public class NodeTestWithSpaghetti extends MUnitWithSpaghetti {
 			}
 		}
 	}
+
+	@Override
+	public boolean shouldRunAutomatically() {
+		return getProject().hasProperty("munit.usenode") && !getProject().property("munit.usenode").equals("false");
+	}
 }

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/NodeTestWithSpaghetti.java
@@ -1,14 +1,8 @@
 package com.prezi.spaghetti.haxe.gradle;
 
-import com.google.common.base.Throwables;
-import com.google.common.io.Files;
-import com.google.common.io.Resources;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.Task;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.internal.ExecAction;
@@ -21,7 +15,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Collections;

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
@@ -9,7 +9,6 @@ import com.prezi.haxe.gradle.HaxeBinaryBase;
 import com.prezi.haxe.gradle.HaxeCompile;
 import com.prezi.haxe.gradle.HaxeExtension;
 import com.prezi.haxe.gradle.HaxeTestBinary;
-import com.prezi.haxe.gradle.HaxeTestCompile;
 import com.prezi.haxe.gradle.incubating.FunctionalSourceSet;
 import com.prezi.spaghetti.bundle.ModuleBundleFactory;
 import com.prezi.spaghetti.gradle.PackageApplication;
@@ -26,17 +25,24 @@ import com.prezi.spaghetti.packaging.ApplicationType;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.tasks.Copy;
 import org.gradle.internal.reflect.Instantiator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.prezi.haxe.gradle.nodetest.HaxeNodeTestCompile;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -100,20 +106,29 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 		haxeExtension.getBinaries().withType(HaxeTestBinary.class).all(new Action<HaxeTestBinary>() {
 			@Override
 			public void execute(final HaxeTestBinary testBinary) {
-				HaxeBasePlugin.createTestCompileTask(project, testBinary, HaxeTestCompile.class);
+				HaxeBasePlugin.createTestCompileTask(project, testBinary, testBinary.getCompileClass());
 
 				registerSpaghettiModuleBinary(project, testBinary, Collections.singleton(testBinary.getCompileTask()), true);
 			}
 		});
+		final Task npmTask = createCopyNodeDependenciesTask(project);
 		spaghettiExtension.getBinaries().withType(HaxeSpaghettiModule.class).all(new Action<HaxeSpaghettiModule>() {
 			@Override
 			public void execute(final HaxeSpaghettiModule moduleBinary) {
 				HaxeBinaryBase<?> binary = moduleBinary.getOriginal();
 				if (moduleBinary.isUsedForTesting() && binary instanceof HaxeTestBinary) {
 					HaxeTestBinary testBinary = (HaxeTestBinary) binary;
-					final PackageApplication appTask = createTestApplication(moduleBinary, testBinary);
+					final PackageApplication appTask;
 
-					MUnitWithSpaghetti munitTask = HaxeBasePlugin.createMUnitTask(project, testBinary, MUnitWithSpaghetti.class);
+					MUnitWithSpaghetti munitTask = null;
+					if (((HaxeTestBinary) binary).getCompileTask() instanceof HaxeNodeTestCompile) {
+						munitTask = HaxeBasePlugin.createMUnitTask(project, testBinary, NodeTestWithSpaghetti.class);
+						munitTask.dependsOn(npmTask);
+						appTask = createTestApplication(moduleBinary, testBinary, ApplicationType.COMMON_JS);
+					} else {
+						munitTask = HaxeBasePlugin.createMUnitTask(project, testBinary, MUnitWithSpaghetti.class);
+						appTask = createTestApplication(moduleBinary, testBinary, ApplicationType.AMD);
+					}
 					munitTask.getConventionMapping().map("testApplication", new Callable<File>() {
 						@Override
 						public File call() throws Exception {
@@ -131,7 +146,7 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 				}
 			}
 
-			private PackageApplication createTestApplication(final HaxeSpaghettiModule moduleBinary, final HaxeTestBinary testBinary) {
+			private PackageApplication createTestApplication(final HaxeSpaghettiModule moduleBinary, final HaxeTestBinary testBinary, ApplicationType applicationType) {
 				String packageTaskName = testBinary.getNamingScheme().getTaskName("package");
 
 				PackageApplication appBundleTask = project.getTasks().create(packageTaskName, PackageApplication.class);
@@ -156,12 +171,47 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 					}
 				});
 				appBundleTask.getConventionMapping().map("applicationName", Callables.returning(testBinary.getName() + "_test.js"));
-				appBundleTask.getConventionMapping().map("type", Callables.returning(ApplicationType.AMD));
+				appBundleTask.getConventionMapping().map("type", Callables.returning(applicationType));
 				appBundleTask.getConventionMapping().map("execute", Callables.returning(false));
 				appBundleTask.dependsOn(moduleBinary.getBundleTask());
 				return appBundleTask;
 			}
 		});
+	}
+
+	private Task createCopyNodeDependenciesTask(final Project project) {
+		final Configuration npmTestConfig = project.getConfigurations().maybeCreate("npmMunitTest");
+		List<String> dependencies = Arrays.asList("npm:requirejs:2.1.8",
+				"npm:jquery:2.1.1",
+				"npm:jsdom:0.10.6-3",
+				"npm:cssstyle:0.2.14",
+				"npm:assert:1.1.1",
+				"npm:chai:1.9.0",
+				"npm:sinon:1.9.1",
+				"npm:mocha:1.17.1",
+				"npm:istanbul:0.2.16",
+				"npm:mocha-istanbul:0.2.0",
+				"npm:spec-xunit-file:0.0.1-2",
+				"npm:canvas:1.2.1");
+
+		DependencyHandler dependencyHandler = project.getDependencies();
+		for (String dependency : dependencies) {
+			dependencyHandler.add(npmTestConfig.getName(), dependencyHandler.create(dependency));
+		}
+
+		Copy npmTask = project.getTasks().create("copyNpmMunitTestDependencies", Copy.class);
+		npmTask.from(new Callable<ConfigurableFileCollection>() {
+			@Override
+			public ConfigurableFileCollection call() throws Exception {
+				ConfigurableFileCollection unzippedFiles = project.files();
+				for (File file : npmTestConfig) {
+					unzippedFiles.from(project.zipTree(file));
+				}
+				return unzippedFiles;
+			}
+		});
+		npmTask.into(Callables.returning(new File(project.getBuildDir(), "munit/node_modules")));
+		return npmTask;
 	}
 
 	private <T extends HaxeBinaryBase<?>> void addSpaghettiSourceSet(final Project project, HaxeExtension haxeExtension, final SpaghettiGeneratedSourceSet spaghettiSourceSet, Class<T> binaryType, String sourceSetName) {

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
@@ -191,7 +191,8 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 
 	private Task createSetupNodeDependenciesTask(final Project project, File nodeModulesDir) {
 		final Configuration npmTestConfig = project.getConfigurations().maybeCreate("npmMunitTest");
-		List<String> dependencies = Arrays.asList("npm:requirejs:2.1.8",
+		List<String> dependencies = Arrays.asList(
+				"npm:requirejs:2.1.8",
 				"npm:jquery:2.1.1",
 				"npm:jsdom:0.10.6-3",
 				"npm:cssstyle:0.2.14",

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
@@ -22,7 +22,6 @@ import com.prezi.spaghetti.gradle.internal.SpaghettiModuleFactory;
 import com.prezi.spaghetti.gradle.internal.incubating.BinaryNamingScheme;
 import com.prezi.spaghetti.haxe.gradle.internal.HaxeSpaghettiModule;
 import com.prezi.spaghetti.packaging.ApplicationType;
-import org.apache.tools.ant.taskdefs.Execute;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
+++ b/gradle-spaghetti-haxe-plugin/src/main/java/com/prezi/spaghetti/haxe/gradle/SpaghettiHaxePlugin.java
@@ -112,7 +112,7 @@ public class SpaghettiHaxePlugin implements Plugin<Project> {
 				registerSpaghettiModuleBinary(project, testBinary, Collections.singleton(testBinary.getCompileTask()), true);
 			}
 		});
-		final File nodeModulesDir =new File(project.getBuildDir(), "munit/node_modules");
+		final File nodeModulesDir = new File(project.getBuildDir(), "munit/node_modules");
 		final Task npmTask = createSetupNodeDependenciesTask(project, nodeModulesDir);
 		spaghettiExtension.getBinaries().withType(HaxeSpaghettiModule.class).all(new Action<HaxeSpaghettiModule>() {
 			@Override

--- a/gradle-spaghetti-haxe-plugin/src/main/resources/munit_node_resources/munit_node_runner.js
+++ b/gradle-spaghetti-haxe-plugin/src/main/resources/munit_node_resources/munit_node_runner.js
@@ -1,12 +1,194 @@
 #!/usr/bin/env node
 
 var jsdom = require("jsdom");
-var Canvas = require('canvas');
-var describe = require("mocha").describe;
+var fs = require('fs');
+var path = require('path');
+
 global.window = jsdom.jsdom().createWindow();
+
 global.document = global.window.document;
 global.$ = require('jquery');
+global.alert = function(){}
+
+exitCode = 0;
+
+var pprt = (function(){
+	var indentLevel = 0;
+	var isFresh = true;
+	var freshLine = function()
+	{
+		if(!isFresh)
+		{
+			process.stdout.write("\n");
+			isFresh = true;
+		}
+	}
+
+	var writeLine = function(x)
+	{
+		write(x);
+		freshLine();
+	}
+
+	var write = function(x)
+	{
+		var first = true;
+		x.split("\n").map(function(line){
+			if(!first)
+				process.stdout.write("\n");
+			first = false;
+			if(isFresh || !first)
+			{
+				for(i=0;i<indentLevel;i++)
+					process.stdout.write("    ");
+			}
+			process.stdout.write(line);
+		
+		});
+		isFresh = false;
+
+	}
+
+	var indent = function()
+	{
+		indentLevel++;		
+	}
+
+	var unindent = function()
+	{
+		indentLevel--;
+	}
+
+	return {
+		freshLine: freshLine,
+		writeLine: writeLine,
+		write: write,
+		indent: indent,
+		unindent: unindent,
+	}
+})();
+
+global.addToQueue = (function ()
+{
+	var oldLog = console.log;
+//	console.log = function(){}
+
+	var trace = [];
+
+	function unhtml(st)
+	{
+		st = st.replace(/&nbsp;/g, ' ');
+		st = st.replace(/<br\/>/g, '\n');
+		return st;
+	}
+
+	function flushTrace()
+	{
+		pprt.indent();
+		while(trace.length)
+			pprt.writeLine(trace.shift());
+		pprt.unindent();
+	}
+
+	
+	function addToQueue(fnc,arg1,arg2,arg3)
+	{
+		arg1 = unhtml(arg1);
+		if(fnc == "updateTestSummary")
+		{
+			pprt.write(unhtml(arg1));
+		}
+		else if(fnc == "setTestClassResult")	
+		{
+
+			switch(arg1)
+			{
+				case "0":
+					pprt.writeLine("PASSED");
+					break;
+				case "1":
+					pprt.writeLine("FAILED");
+					break;
+				case "2":
+					pprt.writeLine("ERROR");
+					break;
+				case "3":
+					//color = COLOR_WARNING;// yellow passed but not covered
+					pprt.writeLine("PASSED");
+					break;
+				default: 
+					break;
+			}
+
+			flushTrace();
+
+		}
+		else if(fnc == "addTestError")
+		{
+			trace.push(arg1);
+
+		}
+		else if(fnc == "createTestClass")	
+		{
+
+		}
+		else if(fnc == "addTestIgnore")	
+		{
+
+		}
+		else if(fnc == "munitTrace")
+		{
+			trace.push(arg1);
+		
+		}
+		else if(fnc == "printSummary")
+		{
+			pprt.freshLine("");
+			oldLog(arg1);	
+		}
+		else if(fnc == "setResult")
+		{
+			flushTrace();
+			exitCode = arg1 == 'true' ? 1 : 0;
+		}
+		else
+		{
+			pprt.freshLine();
+			oldLog("XXXXX", arguments);
+			
+		}
+			
+	}
+
+	return addToQueue;
+})();
+
+
+global.testComplete = function(resultXml, successful){
+
+    function mkdir(path, root) {
+
+        var dirs = path.split('/'), dir = dirs.shift(), root = (root||'')+dir+'/';
+
+        try { fs.mkdirSync(root); }
+        catch (e) {
+            //dir wasn't made, something went wrong
+            if(!fs.statSync(root).isDirectory()) throw new Error(e);
+        }
+
+        return !dirs.length||mkdir(dirs.join('/'), root);
+    }
+
+
+    mkdir('report/test/junit/js/xml');
+    fs.writeFileSync("report/test/junit/js/xml/report.xml", resultXml);
+
+    process.exit(successful ? 0 : 1);
+
+}
+
 
 navigator = {userAgent: {match: function(){}}};
+
 
 require("./nodejsTest_test.js");

--- a/gradle-spaghetti-haxe-plugin/src/main/resources/munit_node_resources/munit_node_runner.js
+++ b/gradle-spaghetti-haxe-plugin/src/main/resources/munit_node_resources/munit_node_runner.js
@@ -1,0 +1,10 @@
+var jsdom = require("jsdom");
+var Canvas = require('canvas');
+var describe = require("mocha").describe;
+global.window = jsdom.jsdom().createWindow();
+global.document = global.window.document;
+global.$ = require('jquery');
+
+navigator = {userAgent: {match: function(){}}};
+
+require("./nodejsTest_test.js");

--- a/gradle-spaghetti-haxe-plugin/src/main/resources/munit_node_resources/munit_node_runner.js
+++ b/gradle-spaghetti-haxe-plugin/src/main/resources/munit_node_resources/munit_node_runner.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var jsdom = require("jsdom");
 var Canvas = require('canvas');
 var describe = require("mocha").describe;


### PR DESCRIPTION
Enable munit tests to run in node.
This pull-request relies on these changes in the `gradle-haxe-plugin`: https://github.com/prezi/gradle-haxe-plugin/pull/37

The goal of this is to be able to run haxe munit tests on not only the browser but on node too. The default runner remains the browser, buth with the `-Pmunit.usenode` flag the tests are run in a node environment (and not in the browser).

The new implementation does not interfere with the old one, there is a different working directory with a different `HaxeBinary`, compile and runner tasks.