### PR TITLE
Add support for configuring Closure compilation level

### DIFF
--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/ObfuscateModule.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/ObfuscateModule.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
 public class ObfuscateModule extends AbstractBundleModuleTask {
 	private final Set<String> additionalSymbols = Sets.newLinkedHashSet();
 	private final Set<Object> closureExterns = Sets.newLinkedHashSet();
+	private String compilationLevel = "advanced";
 	private File workDir;
 	private String nodeSourceMapRoot;
 
@@ -56,7 +57,8 @@ public class ObfuscateModule extends AbstractBundleModuleTask {
 				getNodeSourceMapRoot(),
 				getClosureExterns(),
 				getAdditionalSymbols(),
-				getWorkDir()
+				getWorkDir(),
+				getCompilationLevel()
 		));
 		return super.createBundle(config, module, result.javaScript, result.sourceMap, resourceDir);
 	}
@@ -73,6 +75,11 @@ public class ObfuscateModule extends AbstractBundleModuleTask {
 	public void workDir(String workDir) {
 		setWorkDir(workDir);
 	}
+
+	@Input
+	public String getCompilationLevel() { return compilationLevel; }
+
+	public void setCompilationLevel(String compilationLevel) { this.compilationLevel = compilationLevel; }
 
 	@Input
 	public Set<String> getAdditionalSymbols() {

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ObfuscationParameters.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ObfuscationParameters.java
@@ -1,6 +1,7 @@
 package com.prezi.spaghetti.obfuscation;
 
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.javascript.jscomp.CompilationLevel;
 import com.prezi.spaghetti.ast.ModuleNode;
 import com.prezi.spaghetti.definition.ModuleConfiguration;
 
@@ -22,8 +23,9 @@ public class ObfuscationParameters {
 	public final SortedSet<File> closureExterns;
 	public final SortedSet<String> additionalSymbols;
 	public final File workingDirectory;
+	public final CompilationLevel compilationLevel;
 
-	public ObfuscationParameters(ModuleConfiguration config, ModuleNode module, String javaScript, String sourceMap, URI sourceMapRoot, String nodeSourceMapRoot, Set<File> closureExterns, Set<String> additionalSymbols, File workingDirectory) {
+	public ObfuscationParameters(ModuleConfiguration config, ModuleNode module, String javaScript, String sourceMap, URI sourceMapRoot, String nodeSourceMapRoot, Set<File> closureExterns, Set<String> additionalSymbols, File workingDirectory, CompilationLevel compilationLevel) {
 		this.config = config;
 		this.module = module;
 		this.javaScript = javaScript;
@@ -33,5 +35,22 @@ public class ObfuscationParameters {
 		this.closureExterns = ImmutableSortedSet.copyOf(closureExterns);
 		this.additionalSymbols = ImmutableSortedSet.copyOf(additionalSymbols);
 		this.workingDirectory = workingDirectory;
+		this.compilationLevel = compilationLevel;
+	}
+
+	public ObfuscationParameters(ModuleConfiguration config, ModuleNode module, String javaScript, String sourceMap, URI sourceMapRoot, String nodeSourceMapRoot, Set<File> closureExterns, Set<String> additionalSymbols, File workingDirectory, String compilationLevel) {
+		this(config, module, javaScript, sourceMap, sourceMapRoot, nodeSourceMapRoot, closureExterns, additionalSymbols, workingDirectory, convertCompilationLevel(compilationLevel));
+	}
+
+	private static CompilationLevel convertCompilationLevel(String compilationLevel) {
+		if (compilationLevel.equals("advanced")) {
+			return CompilationLevel.ADVANCED_OPTIMIZATIONS;
+		} else if (compilationLevel.equals("simple")) {
+			return CompilationLevel.SIMPLE_OPTIMIZATIONS;
+		} else if (compilationLevel.equals("whitespace")) {
+			return CompilationLevel.WHITESPACE_ONLY;
+		} else {
+			throw new IllegalArgumentException("Unknown compilation level: " + compilationLevel);
+		}
 	}
 }

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
@@ -36,14 +36,13 @@ public class ClosureCompiler {
 
 	private static Logger logger = LoggerFactory.getLogger(ClosureCompiler.class);
 	private static final int lineLengthThreshold = 1;
-	private static final CompilationLevel compilationLevel = CompilationLevel.ADVANCED_OPTIMIZATIONS;
 
 	/**
 	 * compiles 'jsFileName', appends the obfuscated code to
 	 * 'obfuscated' and appends the source map to 'sourceMap' using
 	 * 'sourceMapName' (the 'file' field in the sourcemap)
 	 */
-	public static int compile(String jsFileName, Appendable obfuscated, String sourceMapName, Appendable sourceMap, Set<File> customExterns) throws IOException {
+	public static int compile(String jsFileName, Appendable obfuscated, String sourceMapName, Appendable sourceMap, CompilationLevel compilationLevel, Set<File> customExterns) throws IOException {
 		com.google.javascript.jscomp.Compiler compiler = new Compiler(System.err);
 		CompilerOptions options = new CompilerOptions();
 

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
@@ -78,6 +78,10 @@ public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 			description = "Obfuscate the output with Closure compiler")
 	private boolean obfuscate;
 
+	@Option(name = {"--compilation-level"},
+			description = "Set the compilation level for Closure compiler")
+	private String compilationLevel = "advanced";
+
 	@Option(name = {"--symbols"},
 			description = "Comma delimited list of additional symbols to protect during obfuscation")
 	private String additionalSymbols;
@@ -177,7 +181,8 @@ public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 				System.getenv("NODE_PATH"),
 				externs,
 				additionalSymbolsSet,
-				workDir
+				workDir,
+				compilationLevel
 		));
 	}
 }


### PR DESCRIPTION
Lets the user choose between levels of optimising compilation: whitespace only, simple, and advanced.

With a choice between only advanced and no optimisation/obfuscation, developers have no option other than falling back to no optimisations when obfuscation causes problems.

Giving more granular control over compilation levels should ease this problem.