### PR TITLE
Remove kotlin-support from settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,6 @@ include "spaghetti-support-test-harness"
 include "spaghetti-haxe-support"
 include 'spaghetti-js-support'
 include "spaghetti-typescript-support"
-include "spaghetti-kotlin-support"
 
 include "gradle-spaghetti-plugin"
 include "gradle-spaghetti-haxe-plugin"


### PR DESCRIPTION
Remove `spaghett-kotlin-support` from `settings.gradle`'s project list, because it no longer exists.