### PR TITLE
Optimize typescript headers

### DIFF
--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/access/TypeScriptModuleAccessorGeneratorVisitor.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/access/TypeScriptModuleAccessorGeneratorVisitor.groovy
@@ -12,35 +12,13 @@ class TypeScriptModuleAccessorGeneratorVisitor extends AbstractTypeScriptGenerat
 
 	@Override
 	String visitModuleNode(ModuleNode node) {
-"""export class ${node.alias} {
-
-	private static ${MODULE}:any = ${GeneratorUtils.createModuleAccessor(node.name)};
-
-${node.methods*.accept(new MethodVisitor(node)).join("")}
+"""interface ${node.alias} {
+${node.methods*.accept(new MethodVisitor()).join("")}
 }
+export var ${node.alias}:${node.alias} = ${GeneratorUtils.createModuleAccessor(node.name)};
 """
 	}
 
 	private static class MethodVisitor extends AbstractTypeScriptMethodGeneratorVisitor {
-
-		private final ModuleNode module
-
-		MethodVisitor(ModuleNode module) {
-			this.module = module
-		}
-
-		@Override
-		String visitMethodNode(MethodNode node) {
-			def returnType = node.returnType.accept(this)
-			def typeParams = node.typeParameters ? "<" + node.typeParameters*.name.join(", ") + ">" : ""
-			def params = node.parameters*.accept(this).join(", ")
-			def paramNames = node.parameters*.name.join(", ")
-
-			return \
-"""	static ${node.name}${typeParams}(${params}):${returnType} {
-		${returnType == "void" ? "" : "return "}${module.alias}.module.${node.name}(${paramNames});
-	}
-"""
-		}
 	}
 }

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/type/enums/TypeScriptOpaqueEnumGeneratorVisitor.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/type/enums/TypeScriptOpaqueEnumGeneratorVisitor.groovy
@@ -6,7 +6,7 @@ import com.prezi.spaghetti.typescript.AbstractTypeScriptGeneratorVisitor
 class TypeScriptOpaqueEnumGeneratorVisitor extends AbstractTypeScriptGeneratorVisitor {
 	@Override
 	String visitEnumNode(EnumNode node) {
-"""export enum ${node.name} {
+"""export declare enum ${node.name} {
 	// Enum members are not generated for transitive dependencies. To generate
 	// the enum type with members, depend directly on the containing module.
 }

--- a/spaghetti-typescript-support/src/test/groovy/com/prezi/spaghetti/typescript/access/TypeScriptModuleAccessorGeneratorVisitorTest.groovy
+++ b/spaghetti-typescript-support/src/test/groovy/com/prezi/spaghetti/typescript/access/TypeScriptModuleAccessorGeneratorVisitorTest.groovy
@@ -27,27 +27,17 @@ module com.example.test {
 		def result = parseAndVisitModule(definition, new TypeScriptModuleAccessorGeneratorVisitor())
 
 		expect:
-		result == """export class TestModule {
-
-	private static module:any = Spaghetti["dependencies"]["com.example.test"]["module"];
-
+		result == """interface TestModule {
 	/**
 	 * Initializes module.
 	 */
-	static initModule(a:number, b?:number):void {
-		TestModule.module.initModule(a, b);
-	}
-	static doSomething():string {
-		return TestModule.module.doSomething();
-	}
-	static doStatic(a:number, b:number):number {
-		return TestModule.module.doStatic(a, b);
-	}
-	static returnT<T>(t:T):com.example.test.MyInterface<T> {
-		return TestModule.module.returnT(t);
-	}
+	initModule(a:number, b?:number):void;
+	doSomething():string;
+	doStatic(a:number, b:number):number;
+	returnT<T>(t:T):com.example.test.MyInterface<T>;
 
 }
+export var TestModule:TestModule = Spaghetti["dependencies"]["com.example.test"]["module"];
 """
 	}
 }


### PR DESCRIPTION
* Don't use `export class` in generated headers, because it generates lots of redundant JS output.
* Use `declare` for transitive enums, because they don't have any members and so no JS should be output for it.