### PR TITLE
Add collector for const struct names

### DIFF
--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/SymbolCollectVisitor.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/SymbolCollectVisitor.java
@@ -54,7 +54,7 @@ public class SymbolCollectVisitor extends ModuleVisitorBase<Collection<String>> 
 
 	@Override
 	public Collection<String> visitConstNode(ConstNode node) {
-		return extractNames(node.getEntries());
+		return ImmutableList.<String>builder().add(node.getName()).addAll(extractNames(node.getEntries())).build();
 	}
 
 	@Override

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/SymbolCollectVisitorTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/SymbolCollectVisitorTest.groovy
@@ -60,7 +60,7 @@ class SymbolCollectVisitorTest extends Specification {
 }
 """
 		expect:
-		result == ["alpha", "beta"]
+		result == ["Constants", "alpha", "beta"]
 	}
 
 	def "enum values are found"() {


### PR DESCRIPTION
In order to expose consts on obfuscated modules, their names need to be added to the set of protected symbols.