### PR TITLE
UMD supports browser globals.

### DIFF
--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/packaging/internal/UmdModuleWrapper.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/packaging/internal/UmdModuleWrapper.java
@@ -70,6 +70,27 @@ public class UmdModuleWrapper extends AbstractModuleWrapper {
 				})))
 				.append(");");
 		//result.append("return module.exports;");
+
+		// Browser Globals
+		Iterable<String> browserGlobalDependencies = Iterables.concat(
+				params.externalDependencies.keySet(),
+				Sets.newTreeSet(params.dependencies)
+		);
+
+		result.append("}else{");
+		result.append("var moduleUrl=(document.getElementById(\"" + params.name + "\")||{src:\"\"}).src;");
+		result.append("baseUrl=moduleUrl.substr(0,moduleUrl.lastIndexOf(\"/\"));");
+		result.append("this[\"" + params.name + "\"]=");
+		result
+				.append("__factory(")
+				.append(Joiner.on(",").join(Iterables.transform(browserGlobalDependencies, new Function<String, String>() {
+					@Nullable
+					@Override
+					public String apply(String name) {
+						return "this[\"" + name + "\"]";
+					}
+				})))
+				.append(");");
 		result.append("}");
 
 		result.append("})();");
@@ -91,6 +112,11 @@ public class UmdModuleWrapper extends AbstractModuleWrapper {
 			result.append("[\"main\"]()");
 		}
 		result.append(";");
+		if (execute) {
+			result.append("}else{");
+			result.append("this[\"").append(mainModule).append("\"]");
+			result.append("[\"main\"]();");
+		}
 		result.append("}\n");
 
 		return result;

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/packaging/UmdModuleWrapperTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/packaging/UmdModuleWrapperTest.groovy
@@ -63,6 +63,10 @@ class UmdModuleWrapperTest extends WrapperTestBase {
 				'}else if(typeof exports==="object"&&typeof exports.nodeName!=="string"){',
 					'baseUrl=__dirname;',
 					'module.exports=(__factory)(require("jquery"),require("react"),require("example.test.name"),require("com.example.alma"),require("com.example.bela"));',
+				'}else{',
+					'var moduleUrl=(document.getElementById("com.example.test")||{src:""}).src;',
+					'baseUrl=moduleUrl.substr(0,moduleUrl.lastIndexOf("/"));',
+					'this["com.example.test"]=__factory(this["\$"],this["React"],this["example.test.name"],this["com.example.alma"],this["com.example.bela"]);',
 				'}',
 				'})();'
 		].join("")
@@ -98,6 +102,8 @@ class UmdModuleWrapperTest extends WrapperTestBase {
 					'});',
 				'}else if(typeof exports==="object"&&typeof exports.nodeName!=="string"){',
 					'require("com.example.test")["main"]();',
+				'}else{',
+					'this["com.example.test"]["main"]();',
 				'}',
 				'\n'
 		].join("")


### PR DESCRIPTION
Support browser global modules.
The term UMD refers a JS module which can be loaded three ways:
 * AMD: using requirejs
 * CommonJS: in Node
 * Browser Globals: attached directly to the Window

If we say we support UMD, we should support the last case as well.
Also the prezipage module in Prezi could benefit from this. Currently we are using a hack to work around the Spaghetti wrapper because there is no support for attaching directly to the window.