### PR TITLE
fix obfuscate module: make compiler path optional input

### DIFF
--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/ObfuscateModule.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/ObfuscateModule.java
@@ -68,6 +68,7 @@ public class ObfuscateModule extends AbstractBundleModuleTask implements NeedsTy
 	}
 
 	@InputDirectory
+	@Optional
 	public File getCompilerPath() {
 		return tsCompilerPath;
 	}


### PR DESCRIPTION
This is only a quickfix, ideally we should only add compilerPath to the inputs when it's needed