### PR TITLE
Fix enum generation for haxe

### DIFF
--- a/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/type/enums/HaxeEnumGeneratorVisitor.groovy
+++ b/spaghetti-haxe-support/src/main/groovy/com/prezi/spaghetti/haxe/type/enums/HaxeEnumGeneratorVisitor.groovy
@@ -15,8 +15,10 @@ class HaxeEnumGeneratorVisitor extends StringModuleVisitorBase {
 ${node.values*.accept(createEnumValueVisitor(node.name)).join("\n")}
 
 	static var _values = {
+		#if js
 		var thisValue = ${enumName};
 		${node.values.collect { entry -> "untyped __js__(\"thisValue[thisValue.${entry.name}] = '${entry.name}'\");" }.join("\n\t\t")}
+		#end
 		[${node.values.collect { entry -> "Std.string(${entry.name}) => ${entry.name}" }.join(", ")}];
 	}
 	static var _names = [${node.values.collect { entry -> "Std.string(${entry.name}) => \"${entry.name}\"" }.join(", ")}];

--- a/spaghetti-haxe-support/src/test/groovy/com/prezi/spaghetti/haxe/type/enums/HaxeEnumGeneratorVisitorTest.groovy
+++ b/spaghetti-haxe-support/src/test/groovy/com/prezi/spaghetti/haxe/type/enums/HaxeEnumGeneratorVisitorTest.groovy
@@ -54,10 +54,12 @@ class HaxeEnumGeneratorVisitorTest extends EnumGeneratorSpecification {
 	public static var GEZA = new MyEnum(${third});
 
 	static var _values = {
+		#if js
 		var thisValue = MyEnum;
 		untyped __js__("thisValue[thisValue.ALMA] = 'ALMA'");
 		untyped __js__("thisValue[thisValue.BELA] = 'BELA'");
 		untyped __js__("thisValue[thisValue.GEZA] = 'GEZA'");
+		#end
 		[Std.string(ALMA) => ALMA, Std.string(BELA) => BELA, Std.string(GEZA) => GEZA];
 	}
 	static var _names = [Std.string(ALMA) => "ALMA", Std.string(BELA) => "BELA", Std.string(GEZA) => "GEZA"];


### PR DESCRIPTION
### Problem

Other languages than js could not compile.

### Solution

Added conditional compile flag for haxe `__js__` code, so it can be compiled to for example Java.