### PR TITLE
Improve merging of .d.ts files

### DIFF
--- a/spaghetti-core/src/main/ts/tsAstParser.ts
+++ b/spaghetti-core/src/main/ts/tsAstParser.ts
@@ -113,9 +113,9 @@ class Linter {
         ts.forEachChild(sourceFile, (node: ts.Node) => {
             if (isSubModule && isRelativeImportExport(node)) {
                 if (node.kind === ts.SyntaxKind.ImportDeclaration) {
-                    this.lintError("relative imports are not permitted in file being merged.", node);
+                    this.lintError("Relative imports are not permitted in file being merged.", node);
                 } else if (node.kind === ts.SyntaxKind.ExportDeclaration) {
-                    this.lintError("exports from relative paths are not permitted a file being merged.", node);
+                    this.lintError("Exports from relative paths are not permitted in a file being merged.", node);
                 }
             }
 
@@ -132,7 +132,7 @@ class Linter {
                     Object.keys(subImportedIds).forEach((name: string) => {
                         if (importedIdentifiers[name] != null
                                 && !importsCanBeMerged(importedIdentifiers[name], subImportedIds[name])) {
-                            subLinter.lintError(`duplicate imported identifier: '${name}'`, subImportedIds[name].node);
+                            subLinter.lintError(`Duplicate imported identifier: '${name}'`, subImportedIds[name].node);
                         }
                     });
 
@@ -156,7 +156,7 @@ class Linter {
                     const exportDeclaration = (<ts.ExportDeclaration>node);
                     const moduleText = getImportExportText(exportDeclaration)!;
                     if (exportDeclaration.exportClause != null) {
-                        this.lintError(`named exports are not supported from relative modules: '${moduleText}'`, exportDeclaration);
+                        this.lintError(`Named exports are not supported from relative modules: '${moduleText}'`, exportDeclaration);
                     } else {
                         exportModules.push(moduleText);
                         statements.push(exportDeclaration);
@@ -167,7 +167,7 @@ class Linter {
         importDeclarations.forEach((importDeclaration) => {
             const moduleText = getImportText(importDeclaration)!;
             if (exportModules.indexOf(moduleText) === -1) {
-                this.lintError(`missing export * from '${moduleText}' statement.`, importDeclaration);
+                this.lintError(`Missing export * from '${moduleText}' statement.`, importDeclaration);
             }
         });
 

--- a/spaghetti-core/src/main/ts/tsAstParser.ts
+++ b/spaghetti-core/src/main/ts/tsAstParser.ts
@@ -87,7 +87,7 @@ class Linter {
 
         var statement: ts.Node = sourceFile.statements[0];
         while (statement.kind === ts.SyntaxKind.ModuleDeclaration) {
-            var body = (<ts.ModuleDeclaration>statement).body
+            var body = (statement as ts.ModuleDeclaration).body
             if (body == null) {
                 break;
             }
@@ -122,7 +122,7 @@ class Linter {
             }
 
             if (!isSubModule && isRelativeImportExport(node) && node.kind === ts.SyntaxKind.ExportDeclaration) {
-                const exportDecl = (<ts.ExportDeclaration>node);
+                const exportDecl = node as ts.ExportDeclaration;
                 if (exportDecl.exportClause == null) {
                     // exportClause is null: 'export * from ...'
                     const filePath = getImportFilePath(sourceFile.fileName, exportDecl);
@@ -154,7 +154,7 @@ class Linter {
                     importDeclarations.push(node as ts.ImportDeclaration);
                     statements.push(node as ts.ImportDeclaration);
                 } else if (node.kind === ts.SyntaxKind.ExportDeclaration) {
-                    const exportDeclaration = (<ts.ExportDeclaration>node);
+                    const exportDeclaration = node as ts.ExportDeclaration;
                     const moduleText = getImportExportText(exportDeclaration)!;
                     if (exportDeclaration.exportClause != null) {
                         this.lintError(`Named exports are not supported from relative modules: '${moduleText}'`, exportDeclaration);
@@ -216,7 +216,7 @@ class Linter {
     lintNode(node: ts.Node) {
         switch (node.kind) {
             case ts.SyntaxKind.VariableStatement:
-                let varDecl = (<ts.VariableStatement>node).declarationList;
+                let varDecl = (node as ts.VariableStatement).declarationList;
                 varDecl.declarations.forEach((n) => this.lintVariableDeclaration(n));
                 if (!(varDecl.flags & ts.NodeFlags.Const)) {
                     this.lintError("'var' and 'let' are not allowed. Please use 'const' instead.", node);
@@ -415,7 +415,7 @@ function getProtectedIdentifiers(sourceFile: ts.SourceFile) {
                 if (node.parent && node.parent.kind === ts.SyntaxKind.InterfaceDeclaration) {
                     break;
                 }
-                let text = (<ts.Identifier>node).text;
+                let text = (node as ts.Identifier).text;
                 idents[text] = text;
                 break;
 
@@ -437,7 +437,7 @@ function getSourceFile(filename: string) {
             fs.readFileSync(filename, 'utf8'),
             ts.ScriptTarget.ES5,
             true);
-    let parseErrors: Array<ts.Diagnostic> = (<any>sourceFile).parseDiagnostics;
+    let parseErrors: Array<ts.Diagnostic> = (sourceFile as any).parseDiagnostics;
     if (parseErrors && parseErrors.length > 0) {
         parseErrors.forEach((error: ts.Diagnostic) => {
             let { line, character } = sourceFile.getLineAndCharacterOfPosition(error.start);

--- a/spaghetti-core/src/main/ts/tsAstParser.ts
+++ b/spaghetti-core/src/main/ts/tsAstParser.ts
@@ -22,21 +22,25 @@ interface BaseImport {
 }
 
 interface DefaultImport extends BaseImport {
+    /* import foo from 'bar'; */
     type: "default-import";
     name: string;
 }
 
 interface StarImport extends BaseImport {
+    /* import * as foo from 'bar'; */
     type: "star-import";
     name: string;
 }
 
 interface NamedImport extends BaseImport {
+    /* import { foo, foo2 } from 'bar'; */
     type: "named-import";
     name: string;
 }
 
 interface NamedWithAliasImport extends BaseImport {
+    /* import { foo as f, foo2 as f2 } from 'bar'; */
     type: "named-with-alias-import";
     name: string;
     propertyName: string;

--- a/spaghetti-core/src/main/ts/tsAstParser.ts
+++ b/spaghetti-core/src/main/ts/tsAstParser.ts
@@ -117,7 +117,7 @@ class Linter {
         ts.forEachChild(sourceFile, (node: ts.Node) => {
             if (isSubModule && isRelativeImportExport(node)) {
                 if (node.kind === ts.SyntaxKind.ImportDeclaration) {
-                    this.lintError("Relative imports are not permitted in file being merged.", node);
+                    this.lintError("Relative imports are not permitted in a file being merged.", node);
                 } else if (node.kind === ts.SyntaxKind.ExportDeclaration) {
                     this.lintError("Exports from relative paths are not permitted in a file being merged.", node);
                 }

--- a/spaghetti-core/src/main/ts/tsAstParser.ts
+++ b/spaghetti-core/src/main/ts/tsAstParser.ts
@@ -137,9 +137,9 @@ class Linter {
         const filePath = path.resolve(path.dirname(filename), relativePath);
         const importContent = fs.readFileSync(filePath, "utf8");
         return [
-            `/* inlined import: start of '${relativePath}' */`,
+            `/* Start of inlined export: '${relativePath}' */`,
             importContent,
-            `/* inlined import: end of '${relativePath}' */`,
+            `/* End of inlined export: '${relativePath}' */`,
         ].join("\n");
     }
 

--- a/spaghetti-core/src/main/ts/tsconfig.json
+++ b/spaghetti-core/src/main/ts/tsconfig.json
@@ -4,7 +4,12 @@
 		"strictNullChecks": true,
 		"noImplicitThis": true,
 		"noImplicitReturns": true,
-		"noFallthroughCasesInSwitch": true
+		"noFallthroughCasesInSwitch": true,
+		"lib": [
+			"es2015",
+			"es2015.core",
+			"es2015.collection"
+		]
 	},
 	"files": [
 		"tsAstParser.ts"

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -475,9 +475,9 @@ export interface A { }
         outputFile.getText() == """// a comment
 /* pre import */  /* post import */
 /* above comment */
-/* pre comment */ /* Start of inlined export: './b.d.ts' */
+/* pre comment */ /* Start of inlined export: './b' */
 export interface Foo { }
-/* End of inlined export: './b.d.ts' */ /* post comment */
+/* End of inlined export: './b' */ /* post comment */
 // another comment
 export interface A { }
 """;
@@ -495,9 +495,9 @@ export * from './b';
         then:
         lines == []
         outputFile.getText() == """/// <reference path="./b" />
-/* Start of inlined export: './b.d.ts' */
+/* Start of inlined export: './b' */
 export interface Foo { }
-/* End of inlined export: './b.d.ts' */
+/* End of inlined export: './b' */
 """;
     }
 

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -422,7 +422,7 @@ export function foo(){};
 """export interface Foo { }""")
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("missing export * from './b' statement")
+        e.output[0].contains("Missing export * from './b' statement")
     }
 
     def "commonsjs: with single import and export statement"() {
@@ -444,7 +444,7 @@ export { a } from './b'
 """export interface Foo { }""")
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("named exports are not supported from relative modules: './b'");
+        e.output[0].contains("Named exports are not supported from relative modules: './b'");
     }
 
     def "commonsjs: imported file cannot contain relative import"() {
@@ -457,7 +457,7 @@ import * as a from './c';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("relative imports are not permitted in file being merged");
+        e.output[0].contains("Relative imports are not permitted in file being merged");
     }
 
     def "commonsjs: imported file can contain non-relative import"() {
@@ -483,7 +483,7 @@ import one from 'react2';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("duplicate imported identifier: 'one'");
+        e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
     def "commonsjs: conflicting import: star import style"() {
@@ -497,7 +497,7 @@ import * as one from 'react2';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("duplicate imported identifier: 'one'");
+        e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
     def "commonsjs: conflicting import: named import style"() {
@@ -511,7 +511,7 @@ import { one } from 'react2';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("duplicate imported identifier: 'one'");
+        e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
     def "commonsjs: conflicting import: named with alias import style"() {
@@ -525,7 +525,7 @@ import { x as one } from 'react';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("duplicate imported identifier: 'one'");
+        e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
 
@@ -646,7 +646,7 @@ export * from './c';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("exports from relative paths are not permitted a file being merged.");
+        e.output[0].contains("Exports from relative paths are not permitted in a file being merged.");
     }
 
     def "commonsjs: with no import and export statement"() {

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -131,19 +131,6 @@ module test {
         lines == []
     }
 
-    def "commonsjs: non-exported are ignored in non-ambient context"() {
-        when:
-        def lines = runMergeDtsForJs("""
-module test {
-    let a = "a";
-    var b;
-    class A {}
-}
-""")
-        then:
-        lines == []
-    }
-
     def "ambient context members are implicitly exported"() {
         when:
         def lines = runVerify("""
@@ -235,7 +222,21 @@ module test {
         return TypeScriptAstParserService.verifyModuleDefinition(dir, compilerPath, definitionFile, logger);
     }
 
-    def "commonJs with no import statements"() {
+
+    def "commonsjs: non-exported are ignored in non-ambient context"() {
+        when:
+        def lines = runMergeDtsForJs("""
+module test {
+    let a = "a";
+    var b;
+    class A {}
+}
+""")
+        then:
+        lines == []
+    }
+
+    def "commonsjs: with no import statements"() {
         when:
         def lines = runMergeDtsForJs("""
 export function foo(){};
@@ -244,7 +245,7 @@ export function foo(){};
         lines == []
     }
 
-    def "commonJs with single import statement"() {
+    def "commonsjs: with single import statement"() {
         when:
         def lines = runMergeDtsForJs("""
 import * as a from './b';
@@ -255,7 +256,7 @@ export function foo(){};
         e.output[0].contains("missing export * from './b' statement")
     }
 
-    def "commonJs with single import and export statement"() {
+    def "commonsjs: with single import and export statement"() {
         when:
         def lines = runMergeDtsForJs("""
 import * as a from './b';
@@ -265,7 +266,7 @@ export * from './b'
         lines == []
     }
 
-    def "commonJs with relative export statement and named exports"() {
+    def "commonsjs: with relative export statement and named exports"() {
         when:
         def lines = runMergeDtsForJs("""
 export { a } from './b'
@@ -275,7 +276,7 @@ export { a } from './b'
         e.output[0].contains("named exports are not supported from relative modules: './b'");
     }
 
-    def "commonJs with no import and export statement"() {
+    def "commonsjs: with no import and export statement"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -284,7 +285,7 @@ export * from './b'
         lines == []
     }
 
-    def "commonJs with no import and export statement"() {
+    def "commonsjs: with no import and export statement"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();
@@ -309,7 +310,7 @@ export interface A { }
 """;
     }
 
-    def "commonJs with reference path"() {
+    def "commonsjs: with reference path"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -302,9 +302,9 @@ export interface A { }
         outputFile.getText() == """// a comment
 /* pre import */  /* post import */
 /* above comment */
-/* pre comment */ /* inlined import: start of './b.d.ts' */
+/* pre comment */ /* Start of inlined export: './b.d.ts' */
 export interface Foo { }
-/* inlined import: end of './b.d.ts' */ /* post comment */
+/* End of inlined export: './b.d.ts' */ /* post comment */
 // another comment
 export interface A { }
 """;
@@ -321,9 +321,9 @@ export * from './b';
         then:
         lines == []
         outputFile.getText() == """/// <reference path="./b" />
-/* inlined import: start of './b.d.ts' */
+/* Start of inlined export: './b.d.ts' */
 export interface Foo { }
-/* inlined import: end of './b.d.ts' */
+/* End of inlined export: './b.d.ts' */
 """;
     }
 

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -447,6 +447,44 @@ export { a } from './b'
         e.output[0].contains("named exports are not supported from relative modules: './b'");
     }
 
+    def "commonsjs: imported file cannot contain relative import"() {
+        when:
+        def lines = runMergeDtsForJs("""
+export * from './b'
+""",
+"""
+import * as a from './c';
+""")
+        then:
+        def e = thrown(TypeScriptAstParserException)
+        e.output[0].contains("relative imports are not permitted in file being merged");
+    }
+
+    def "commonsjs: imported file can contain non-relative import"() {
+        when:
+        def lines = runMergeDtsForJs("""
+export * from './b'
+""",
+"""
+import * as a from 'react';
+""")
+        then:
+        lines == []
+    }
+
+    def "commonsjs: imported file cannot contain relative export"() {
+        when:
+        def lines = runMergeDtsForJs("""
+export * from './b'
+""",
+"""
+export * from './c';
+""")
+        then:
+        def e = thrown(TypeScriptAstParserException)
+        e.output[0].contains("exports from relative paths are not permitted a file being merged.");
+    }
+
     def "commonsjs: with no import and export statement"() {
         when:
         def lines = runMergeDtsForJs("""

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -404,7 +404,7 @@ checkImported)
         checkImported << [false, true]
     }
 
-    def "commonsjs: with no import statements"() {
+    def "commonjs: with no import statements"() {
         when:
         def lines = runMergeDtsForJs("""
 export function foo(){};
@@ -413,7 +413,7 @@ export function foo(){};
         lines == []
     }
 
-    def "commonsjs: with single import statement"() {
+    def "commonjs: with single import statement"() {
         when:
         def lines = runMergeDtsForJs("""
 import * as a from './b';
@@ -425,7 +425,7 @@ export function foo(){};
         e.output[0].contains("Missing export * from './b' statement")
     }
 
-    def "commonsjs: with single import and export statement"() {
+    def "commonjs: with single import and export statement"() {
         when:
         def lines = runMergeDtsForJs("""
 import * as a from './b';
@@ -436,7 +436,7 @@ export * from './b'
         lines == []
     }
 
-    def "commonsjs: with relative export statement and named exports"() {
+    def "commonjs: with relative export statement and named exports"() {
         when:
         def lines = runMergeDtsForJs("""
 export { a } from './b'
@@ -447,7 +447,7 @@ export { a } from './b'
         e.output[0].contains("Named exports are not supported from relative modules: './b'");
     }
 
-    def "commonsjs: imported file cannot contain relative import"() {
+    def "commonjs: imported file cannot contain relative import"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -460,7 +460,7 @@ import * as a from './c';
         e.output[0].contains("Relative imports are not permitted in a file being merged");
     }
 
-    def "commonsjs: imported file can contain non-relative import"() {
+    def "commonjs: imported file can contain non-relative import"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -472,7 +472,7 @@ import * as a from 'react';
         lines == []
     }
 
-    def "commonsjs: conflicting import: default import style"() {
+    def "commonjs: conflicting import: default import style"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -486,7 +486,7 @@ import one from 'react2';
         e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
-    def "commonsjs: conflicting import: star import style"() {
+    def "commonjs: conflicting import: star import style"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -500,7 +500,7 @@ import * as one from 'react2';
         e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
-    def "commonsjs: conflicting import: named import style"() {
+    def "commonjs: conflicting import: named import style"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -514,7 +514,7 @@ import { one } from 'react2';
         e.output[0].contains("Duplicate imported identifier: 'one'");
     }
 
-    def "commonsjs: conflicting import: named with alias import style"() {
+    def "commonjs: conflicting import: named with alias import style"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -529,7 +529,7 @@ import { x as one } from 'react';
     }
 
 
-    def "commonsjs: merged import: default import style"() {
+    def "commonjs: merged import: default import style"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();
@@ -557,7 +557,7 @@ export interface Foo { }
 """;
     }
 
-    def "commonsjs: merged import: star import style"() {
+    def "commonjs: merged import: star import style"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();
@@ -585,7 +585,7 @@ export interface Foo { }
 """;
     }
 
-    def "commonsjs: merged import: named import style"() {
+    def "commonjs: merged import: named import style"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();
@@ -612,7 +612,7 @@ export interface Foo { }
     }
 
 
-    def "commonsjs: merged import: named with alias import style"() {
+    def "commonjs: merged import: named with alias import style"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();
@@ -636,7 +636,7 @@ export interface Foo { }
 """;
     }
 
-    def "commonsjs: imported file cannot contain relative export"() {
+    def "commonjs: imported file cannot contain relative export"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -649,7 +649,7 @@ export * from './c';
         e.output[0].contains("Exports from relative paths are not permitted in a file being merged.");
     }
 
-    def "commonsjs: with no import and export statement"() {
+    def "commonjs: with no import and export statement"() {
         when:
         def lines = runMergeDtsForJs("""
 export * from './b'
@@ -659,7 +659,7 @@ export * from './b'
         lines == []
     }
 
-    def "commonsjs: with no import and export statement"() {
+    def "commonjs: with no import and export statement"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();
@@ -685,7 +685,7 @@ export interface A { }
 """;
     }
 
-    def "commonsjs: with reference path"() {
+    def "commonjs: with reference path"() {
         when:
         File dir = Files.createTempDirectory("TypeScriptAstParserServiceTest").toFile();
         dir.mkdirs();

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -457,7 +457,7 @@ import * as a from './c';
 """)
         then:
         def e = thrown(TypeScriptAstParserException)
-        e.output[0].contains("Relative imports are not permitted in file being merged");
+        e.output[0].contains("Relative imports are not permitted in a file being merged");
     }
 
     def "commonsjs: imported file can contain non-relative import"() {


### PR DESCRIPTION
 * Checks syntax of inlined modules, not just the main `*.module.ts`
 * Doesn't allow relative imports inside the inlined modules
 * Removes duplicate imports from the inlined module (if the same import is already in the `*.module.ts`