### PR TITLE
Revert closure compiler language input to ES5

### DIFF
--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
@@ -58,7 +58,7 @@ public class ClosureCompiler {
 
 		add(args, "--compilation_level", compilationLevel.name());
 
-		add(args, "--language_in", "ECMASCRIPT6");
+		add(args, "--language_in", "ECMASCRIPT5");
 
 		add(args, "--jscomp_off", "checkVars");
 		add(args, "--jscomp_off", "checkTypes");
@@ -96,7 +96,7 @@ public class ClosureCompiler {
 		add(args, "--module_resolution", "NODE");
 		add(args, "--dependency_mode", "STRICT");
 		add(args, "--compilation_level", compilationLevel.name());
-		add(args, "--language_in", "ECMASCRIPT6_STRICT");
+		add(args, "--language_in", "ECMASCRIPT5_STRICT");
 		add(args, "--language_out", "ECMASCRIPT5_STRICT");
 		add(args, "--entry_point", entryPoint.getAbsolutePath());
 		add(args, "--js_output_file", outputFile.getAbsolutePath());


### PR DESCRIPTION
We tried to solve a different problem by setting the language input of closure compiler to ES6 (https://github.com/prezi/spaghetti/pull/249) but it didn't turn out well so I set it back to ES5.