### PR TITLE
Introduce es6 target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,8 +149,8 @@ ext.javaProjects = codeProjects - groovyProjects
 configure(codeProjects) {
 	apply plugin: 'groovy'
 
-	sourceCompatibility = "1.6"
-	targetCompatibility = "1.6"
+	sourceCompatibility = "1.8"
+	targetCompatibility = "1.8"
 
 	sourceSets {
 		integTest {

--- a/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/ObfuscateModule.java
+++ b/gradle-spaghetti-plugin/src/main/java/com/prezi/spaghetti/gradle/ObfuscateModule.java
@@ -24,6 +24,7 @@ public class ObfuscateModule extends AbstractBundleModuleTask implements NeedsTy
 	private final Set<String> additionalSymbols = Sets.newLinkedHashSet();
 	private final Set<Object> closureExterns = Sets.newLinkedHashSet();
 	private String compilationLevel = "advanced";
+	private String closureTarget = "es5";
 	private File workDir;
 	private String nodeSourceMapRoot;
 	private File tsCompilerPath;
@@ -62,7 +63,8 @@ public class ObfuscateModule extends AbstractBundleModuleTask implements NeedsTy
 				getWorkDir(),
 				getCompilerPath(),
 				getLogger(),
-				getCompilationLevel()
+				getCompilationLevel(),
+				getClosureTarget()
 		));
 		return super.createBundle(config, result.javaScript, result.sourceMap, resourceDir);
 	}
@@ -129,5 +131,14 @@ public class ObfuscateModule extends AbstractBundleModuleTask implements NeedsTy
 	@SuppressWarnings("UnusedDeclaration")
 	public void nodeSourceMapRoot(String sourceMapRoot) {
 		this.nodeSourceMapRoot = sourceMapRoot;
+	}
+
+	@Input
+	public String getClosureTarget() {
+		return closureTarget;
+	}
+
+	public void setClosureTarget(String closureTarget) {
+		this.closureTarget = closureTarget;
 	}
 }

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+import com.prezi.spaghetti.obfuscation.ObfuscationParameters;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
@@ -34,6 +35,7 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 	private Set<String> nodeRequireDependencies = Sets.newHashSet();
 	private Collection<File> entryPoints = null;
 	private DefinitionFile definition = null;
+	private String closureTarget = "es5";
 
 	@Input
 	public File getWorkDir() {
@@ -103,6 +105,15 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 		this.entryPoints = files;
 	}
 
+	@Input
+	public String getClosureTarget() {
+		return closureTarget;
+	}
+
+	public void setClosureTarget(String closureTarget) {
+		this.closureTarget = closureTarget;
+	}
+
 	@TaskAction
 	public void concat() throws IOException, InterruptedException {
 		File workDir = getWorkDir();
@@ -144,7 +155,8 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 			mainEntryPoint,
 			inputFiles,
 			Sets.<File>newHashSet(),
-			CompilationLevel.WHITESPACE_ONLY);
+			CompilationLevel.WHITESPACE_ONLY,
+			ObfuscationParameters.convertClosureTarget(getClosureTarget()));
 
 		if (exitValue != 0) {
 			throw new RuntimeException("Closure Compiler return an error code: " + exitValue);

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ClosureTarget.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ClosureTarget.java
@@ -1,0 +1,6 @@
+package com.prezi.spaghetti.obfuscation;
+
+public enum ClosureTarget {
+	ES5,
+	ES6
+}

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ModuleObfuscator.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ModuleObfuscator.java
@@ -104,7 +104,7 @@ public class ModuleObfuscator {
 		}
 
 		// Hand off for compilation
-		Integer closureRet = ClosureCompiler.compile(workDir, inputFile, outputFile, outputSourceMapFile, params.compilationLevel, externs);
+		Integer closureRet = ClosureCompiler.compile(workDir, inputFile, outputFile, outputSourceMapFile, params.compilationLevel, externs, params.closureTarget);
 		if (closureRet != 0) {
 			throw new RuntimeException("Closure returned with exit code " + closureRet);
 		}

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ObfuscationParameters.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/ObfuscationParameters.java
@@ -27,8 +27,9 @@ public class ObfuscationParameters {
 	public final File tsCompilerPath;
 	public final Logger logger;
 	public final CompilationLevel compilationLevel;
+	public final ClosureTarget closureTarget;
 
-	public ObfuscationParameters(ModuleConfiguration config, ModuleNode module, String javaScript, String sourceMap, URI sourceMapRoot, String nodeSourceMapRoot, Set<File> closureExterns, Set<String> additionalSymbols, File workingDirectory, File tsCompilerPath, Logger logger, CompilationLevel compilationLevel) {
+	public ObfuscationParameters(ModuleConfiguration config, ModuleNode module, String javaScript, String sourceMap, URI sourceMapRoot, String nodeSourceMapRoot, Set<File> closureExterns, Set<String> additionalSymbols, File workingDirectory, File tsCompilerPath, Logger logger, CompilationLevel compilationLevel, ClosureTarget closureTarget) {
 		this.config = config;
 		this.module = module;
 		this.javaScript = javaScript;
@@ -41,10 +42,25 @@ public class ObfuscationParameters {
 		this.tsCompilerPath = tsCompilerPath;
 		this.logger = logger;
 		this.compilationLevel = compilationLevel;
+		this.closureTarget = closureTarget;
 	}
 
-	public ObfuscationParameters(ModuleConfiguration config, ModuleNode module, String javaScript, String sourceMap, URI sourceMapRoot, String nodeSourceMapRoot, Set<File> closureExterns, Set<String> additionalSymbols, File workingDirectory, File tsCompilerPath, Logger logger, String compilationLevel) {
-		this(config, module, javaScript, sourceMap, sourceMapRoot, nodeSourceMapRoot, closureExterns, additionalSymbols, workingDirectory, tsCompilerPath, logger, convertCompilationLevel(compilationLevel));
+	public ObfuscationParameters(
+			ModuleConfiguration config,
+			ModuleNode module,
+			String javaScript,
+			String sourceMap,
+			URI sourceMapRoot,
+			String nodeSourceMapRoot,
+			Set<File> closureExterns,
+			Set<String> additionalSymbols,
+			File workingDirectory,
+			File tsCompilerPath,
+			Logger logger,
+			String compilationLevel,
+			String closureTarget
+	) {
+		this(config, module, javaScript, sourceMap, sourceMapRoot, nodeSourceMapRoot, closureExterns, additionalSymbols, workingDirectory, tsCompilerPath, logger, convertCompilationLevel(compilationLevel), convertClosureTarget(closureTarget));
 	}
 
 	private static CompilationLevel convertCompilationLevel(String compilationLevel) {
@@ -56,6 +72,16 @@ public class ObfuscationParameters {
 			return CompilationLevel.WHITESPACE_ONLY;
 		} else {
 			throw new IllegalArgumentException("Unknown compilation level: " + compilationLevel);
+		}
+	}
+
+	public static ClosureTarget convertClosureTarget(String closureTarget) {
+		if (closureTarget.equalsIgnoreCase("es5")) {
+			return ClosureTarget.ES5;
+		} else if (closureTarget.equalsIgnoreCase("es6")) {
+			return ClosureTarget.ES6;
+		} else {
+			throw new IllegalArgumentException("Unknown closure target level: " + closureTarget);
 		}
 	}
 }

--- a/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
+++ b/spaghetti/src/main/java/com/prezi/spaghetti/cli/commands/BundleModuleCommand.java
@@ -35,8 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
-import org.slf4j.LoggerFactory;
-
 @Command(name = "bundle", description = "Create a module bundle.")
 public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 	@Option(name = {"-T", "--type"},
@@ -84,6 +82,10 @@ public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 	@Option(name = {"--compilation-level"},
 			description = "Set the compilation level for Closure compiler")
 	private String compilationLevel = "advanced";
+
+	@Option(name = {"--closure-target"},
+			description = "Set the target for Closure compiler (es5|es6)")
+	private String closureTarget = "es5";
 
 	@Option(name = {"--symbols"},
 			description = "Comma delimited list of additional symbols to protect during obfuscation")
@@ -191,7 +193,8 @@ public class BundleModuleCommand extends AbstractLanguageAwareCommand {
 				workDir,
 				new File(nodePath, "typescript"),
 				BundleModuleCommand.logger,
-				compilationLevel
+				compilationLevel,
+				closureTarget
 		));
 	}
 }


### PR DESCRIPTION
**Needs major bump.**

Changed `sourceCompatibility` and `targetCompatibility` to `1.8`.

Closure compiler now has a target property:
* `es5` or `es6`
* by default it's `es5` to remain backward compatible

Bumped closure compiler to handle es6 classes.

Flags required for es6:
* `--emit_use_strict false`: so that Closure does not add `"use strict";` to the start of output. It would break module wrapping.
* `--rewrite_polyfills false`: so that Closure does not generate polyfills. It would break module wrapping. We use Closure only for obfuscation, concatenation, if we use polyfills it should already be in the code.