### PR TITLE
Closure java api wrapper

### DIFF
--- a/closure-compiler-wrapper/build.gradle
+++ b/closure-compiler-wrapper/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+    compile "com.google.javascript:closure-compiler:v20180204"
+    compile "args4j:args4j:2.33"
+
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'com.prezi.spaghetti.closure.ClosureWrapper'
+    }
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
+
+javadoc.enabled = false

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -63,12 +63,13 @@ class ClosureWrapper {
         Compiler compiler = new Compiler(System.err);
         CompilerOptions options = new CompilerOptions();
 
-        CompilationLevel level = CompilationLevel.WHITESPACE_ONLY;
+        CompilationLevel level = CompilationLevel.SIMPLE_OPTIMIZATIONS;
         level.setOptionsForCompilationLevel(options);
         level.setWrappedOutputOptimizations(options);
         options.setProcessCommonJSModules(true);
         options.setTrustedStrings(true);
         options.setEnvironment(CompilerOptions.Environment.BROWSER);
+        options.setConvertToDottedProperties(false);
         options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
         // Dependency mode STRICT
         options.setDependencyOptions(new DependencyOptions()

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -1,8 +1,8 @@
 package com.prezi.spaghetti.closure;
 
 import com.google.javascript.jscomp.deps.ModuleLoader;
-import com.google.javascript.jscomp.AbstractCommandLineRunner;
 import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilationLevel;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.Compiler;
@@ -28,10 +28,10 @@ class Args {
     public List<String> entryPoints = new ArrayList<String>();
 
     @Option(name="--js")
-    public List<File> inputSources = new ArrayList<File>();
+    public List<String> inputPatterns = new ArrayList<String>();
 
     @Option(name="--externs")
-    public List<File> externsSources = new ArrayList<File>();
+    public List<String> externsPatterns = new ArrayList<String>();
 
     @Option(name="--target")
     public String target = "none";
@@ -86,16 +86,17 @@ class ClosureWrapper {
         options.setWarningLevel(DiagnosticGroups.CHECK_VARIABLES, CheckLevel.ERROR);
 
         List<SourceFile> externs = new ArrayList<SourceFile>();
-        for (File f : parsedArgs.externsSources) {
-            externs.add(SourceFile.fromFile(f));
+        for (String path : CommandLineRunner.findJsFiles(parsedArgs.externsPatterns)) {
+            externs.add(SourceFile.fromFile(path));
         }
 
         List<SourceFile> inputs = new ArrayList<SourceFile>();
-        for (File f : parsedArgs.inputSources) {
-            inputs.add(SourceFile.fromFile(f));
+        for (String path : CommandLineRunner.findJsFiles(parsedArgs.inputPatterns)) {
+            inputs.add(SourceFile.fromFile(path));
         }
 
         compiler.compile(externs, inputs, options);
+
         if (compiler.hasErrors()) {
             System.exit(1);
         } else {

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -1,6 +1,7 @@
 package com.prezi.spaghetti.closure;
 
 import com.google.javascript.jscomp.deps.ModuleLoader;
+import com.google.javascript.jscomp.AbstractCommandLineRunner;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.CompilationLevel;
@@ -67,6 +68,7 @@ class ClosureWrapper {
         level.setWrappedOutputOptimizations(options);
         options.setProcessCommonJSModules(true);
         options.setTrustedStrings(true);
+        options.setEnvironment(CompilerOptions.Environment.BROWSER);
         options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
         // Dependency mode STRICT
         options.setDependencyOptions(new DependencyOptions()
@@ -86,6 +88,7 @@ class ClosureWrapper {
         options.setWarningLevel(DiagnosticGroups.CHECK_VARIABLES, CheckLevel.ERROR);
 
         List<SourceFile> externs = new ArrayList<SourceFile>();
+        externs.addAll(AbstractCommandLineRunner.getBuiltinExterns(options.getEnvironment()));
         for (String path : CommandLineRunner.findJsFiles(parsedArgs.externsPatterns)) {
             externs.add(SourceFile.fromFile(path));
         }

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -1,0 +1,108 @@
+package com.prezi.spaghetti.closure;
+
+import com.google.javascript.jscomp.deps.ModuleLoader;
+import com.google.javascript.jscomp.AbstractCommandLineRunner;
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.CompilationLevel;
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.DependencyOptions;
+import com.google.javascript.jscomp.DiagnosticGroups;
+import com.google.javascript.jscomp.ModuleIdentifier;
+import com.google.javascript.jscomp.SourceFile;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+class Args {
+    @Option(name="--js_output_file")
+    public File outputFile;
+
+    @Option(name="--entry_point")
+    public List<File> entryPoints = new ArrayList<File>();
+
+    @Option(name="--js")
+    public List<File> inputSources = new ArrayList<File>();
+
+    @Option(name="--externs")
+    public List<File> externsSources = new ArrayList<File>();
+
+    @Option(name="--target")
+    public String target = "none";
+}
+
+class ClosureWrapper {
+
+    private static List<ModuleIdentifier> getEntryPoints(List<File> entryFiles) {
+        List<ModuleIdentifier> entryPoints = new ArrayList<ModuleIdentifier>();
+        for (File f : entryFiles) {
+            entryPoints.add(ModuleIdentifier.forFile(f.getAbsolutePath()));
+        }
+        return entryPoints;
+    }
+
+    public static void main(String[] args) throws IOException {
+        Args parsedArgs = new Args();
+        CmdLineParser parser = new CmdLineParser(parsedArgs);
+
+        try {
+            parser.parseArgument(args);
+        } catch (CmdLineException e) {
+            System.err.println(e.getMessage());
+            parser.printUsage(System.err);
+            return;
+        }
+
+        Compiler compiler = new Compiler(System.err);
+        CompilerOptions options = new CompilerOptions();
+
+        CompilationLevel level = CompilationLevel.WHITESPACE_ONLY;
+        level.setOptionsForCompilationLevel(options);
+        level.setWrappedOutputOptimizations(options);
+        options.setProcessCommonJSModules(true);
+        options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
+        // Dependency mode STRICT
+        options.setDependencyOptions(new DependencyOptions()
+            .setDependencyPruning(true)
+            .setDependencySorting(true)
+            .setMoocherDropping(true)
+            .setEntryPoints(getEntryPoints(parsedArgs.entryPoints)));
+
+        if (parsedArgs.target.toUpperCase().equals("ES5")) {
+            options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT5_STRICT);
+            options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5_STRICT);
+        } else {
+            options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2015);
+            options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT_2015);
+        }
+
+        options.setWarningLevel(DiagnosticGroups.CHECK_VARIABLES, CheckLevel.ERROR);
+
+        List<SourceFile> externs = new ArrayList<SourceFile>();
+        for (File f : parsedArgs.externsSources) {
+            externs.add(SourceFile.fromFile(f));
+        }
+
+        List<SourceFile> inputs = new ArrayList<SourceFile>();
+        for (File f : parsedArgs.inputSources) {
+            inputs.add(SourceFile.fromFile(f));
+        }
+
+        compiler.compile(externs, inputs, options);
+        if (compiler.hasErrors()) {
+            System.exit(1);
+        } else {
+            Writer writer = new FileWriter(parsedArgs.outputFile);
+            writer.write(compiler.toSource());
+            writer.write("\n");
+            writer.close();
+            System.out.println("Wrote: " + parsedArgs.outputFile.getAbsolutePath());
+        }
+    }
+}

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -25,7 +25,7 @@ class Args {
     public File outputFile;
 
     @Option(name="--entry_point")
-    public List<File> entryPoints = new ArrayList<File>();
+    public List<String> entryPoints = new ArrayList<String>();
 
     @Option(name="--js")
     public List<File> inputSources = new ArrayList<File>();
@@ -39,10 +39,10 @@ class Args {
 
 class ClosureWrapper {
 
-    private static List<ModuleIdentifier> getEntryPoints(List<File> entryFiles) {
+    private static List<ModuleIdentifier> getEntryPoints(List<String> entryFiles) {
         List<ModuleIdentifier> entryPoints = new ArrayList<ModuleIdentifier>();
-        for (File f : entryFiles) {
-            entryPoints.add(ModuleIdentifier.forFile(f.getAbsolutePath()));
+        for (String s : entryFiles) {
+            entryPoints.add(ModuleIdentifier.forFile(s));
         }
         return entryPoints;
     }

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -66,6 +66,7 @@ class ClosureWrapper {
         level.setOptionsForCompilationLevel(options);
         level.setWrappedOutputOptimizations(options);
         options.setProcessCommonJSModules(true);
+        options.setTrustedStrings(true);
         options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
         // Dependency mode STRICT
         options.setDependencyOptions(new DependencyOptions()

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -142,7 +142,7 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 
 		Collection<File> inputFiles = FileUtils.listFiles(jsFilesDir, new String[] {"js"}, true);
 		Collection<File> entryPointFiles = filterFileList(inputFiles, getEntryPoints());
-		File mainEntryPoint = new File(workDir, "_spaghetti-main.js");
+		File mainEntryPoint = new File(workDir, "_spaghetti-entry.js");
 		ClosureUtils.writeMainEntryPoint(
 			mainEntryPoint,
 			entryPointFiles,

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -155,7 +155,6 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 			mainEntryPoint,
 			inputFiles,
 			Sets.<File>newHashSet(),
-			CompilationLevel.WHITESPACE_ONLY,
 			ObfuscationParameters.convertClosureTarget(getClosureTarget()));
 
 		if (exitValue != 0) {

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -140,20 +140,22 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 				String.format("var _require=require;\nmodule.exports = _require('%s');\n", name));
 		}
 
-		Collection<File> inputFiles = FileUtils.listFiles(jsFilesDir, new String[] {"js"}, true);
-		Collection<File> entryPointFiles = filterFileList(inputFiles, getEntryPoints());
+		Collection<File> entryPointFiles = filterFileList(
+			FileUtils.listFiles(jsFilesDir, new String[] {"js"}, true),
+			getEntryPoints());
 		File mainEntryPoint = new File(workDir, "_spaghetti-entry.js");
 		ClosureUtils.writeMainEntryPoint(
 			mainEntryPoint,
 			entryPointFiles,
 			config.getLocalModule().getName());
-		inputFiles.add(mainEntryPoint);
+		File relativeJsDir = new File(jsFilesDir.getName());
+		File relativeEntryPoint = new File(mainEntryPoint.getName());
 
 		int exitValue = ClosureCompiler.concat(
 			workDir,
 			getOutputFile(),
-			mainEntryPoint,
-			inputFiles,
+			relativeEntryPoint,
+			Lists.newArrayList(relativeJsDir, relativeEntryPoint),
 			Sets.<File>newHashSet(),
 			ObfuscationParameters.convertClosureTarget(getClosureTarget()));
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,3 +12,5 @@ include "spaghetti-typescript-support"
 include "gradle-spaghetti-plugin"
 include "gradle-spaghetti-haxe-plugin"
 include "gradle-spaghetti-typescript-plugin"
+
+include "closure-compiler-wrapper"

--- a/spaghetti-core/build.gradle
+++ b/spaghetti-core/build.gradle
@@ -33,15 +33,6 @@ task generateGrammar(type: JavaExec) {
 	classpath = configurations.antlr
 }
 
-processResources {
-	inputs.property "version", version
-	filesMatching('*.properties') {
-		filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [
-				version: version
-		])
-	}
-}
-
 idea.module {
 	sourceDirs += generatedGrammar
 	excludeDirs -= project.buildDir
@@ -103,8 +94,25 @@ task compileTsAstParser {
 	}
 }
 
-processResources.dependsOn compileTsAstParser
-processResources.from compileTsAstParser.outputs.files
+processResources {
+	// Add compiled tsAstParser.js
+	dependsOn compileTsAstParser
+	from compileTsAstParser.outputs.files
+
+	// Add compiled closure-compiler-wrapper.jar
+	dependsOn project(":closure-compiler-wrapper").jar
+	from project(":closure-compiler-wrapper").jar.outputs.files
+	rename "closure-compiler-wrapper-(.*)\\.jar", "closure-compiler-wrapper.jar"
+
+	// Put version into spaghetti.properties
+	inputs.property "version", version
+	filesMatching('*.properties') {
+		filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [
+				version: version
+		])
+	}
+}
+
 
 artifacts {
 	testCompile(testJar)

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
@@ -57,7 +57,7 @@ public class ClosureCompiler {
 			ClosureTarget target
 	) throws IOException, InterruptedException {
 
-		File jarPath = copyJarFile(workDir);
+		File jarPath = copyJarFile(workDir, "/closure-compiler/closure-compiler-v20180204.jar");
 
 		List<String> args = Lists.newArrayList();
 		args.add("java");
@@ -108,21 +108,12 @@ public class ClosureCompiler {
 			CompilationLevel compilationLevel,
 			ClosureTarget target
 	) throws IOException, InterruptedException   {
-		File jarPath = copyJarFile(workDir);
+		File jarPath = copyJarFile(workDir, "/closure-compiler-wrapper.jar");
 		List<String> args = Lists.newArrayList();
 		args.add("java");
 		add(args, "-jar", jarPath.getAbsolutePath());
-		args.add("--assume_function_wrapper");
-		args.add("--process_common_js_modules");
-		add(args, "--module_resolution", "NODE");
-		add(args, "--dependency_mode", "STRICT");
-		add(args, "--compilation_level", compilationLevel.name());
 		if (target.equals(ClosureTarget.ES5)) {
-			add(args, "--language_in", "ECMASCRIPT5_STRICT");
-			add(args, "--language_out", "ECMASCRIPT5_STRICT");
-		} else if (target.equals(ClosureTarget.ES6)) {
-			add(args, "--language_in", "ECMASCRIPT6_STRICT");
-			add(args, "--language_out", "ECMASCRIPT6_STRICT");
+			add(args, "--target", "ES5");
 		}
 		add(args, "--entry_point", entryPoint.getAbsolutePath());
 		add(args, "--js_output_file", outputFile.getAbsolutePath());
@@ -148,10 +139,10 @@ public class ClosureCompiler {
 		return retCode;
 	}
 
-	private static File copyJarFile(File workDir) throws IOException {
+	private static File copyJarFile(File workDir, String resourceName) throws IOException {
 		File jarPath = new File(workDir, "closure.jar");
 		FileUtils.copyURLToFile(
-			Resources.getResource(ClosureCompiler.class, "/closure-compiler/closure-compiler-v20180204.jar"),
+			Resources.getResource(ClosureCompiler.class, resourceName),
 			jarPath
 		);
 

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
@@ -114,19 +114,21 @@ public class ClosureCompiler {
 		if (target.equals(ClosureTarget.ES5)) {
 			add(args, "--target", "ES5");
 		}
-		add(args, "--entry_point", entryPoint.getAbsolutePath());
-		add(args, "--js_output_file", outputFile.getAbsolutePath());
+		add(args, "--entry_point", entryPoint.getPath());
+		add(args, "--js_output_file", outputFile.getPath());
 
 		for (File inputSource : inputSources) {
-			add(args, "--js", inputSource.getAbsolutePath());
+			add(args, "--js", inputSource.getPath());
 		}
 
 		for (File customExtern : customExterns) {
-			add(args, "--externs", customExtern.getAbsolutePath());
+			add(args, "--externs", customExtern.getPath());
 		}
 
+		logger.info("In working directory: {}", workDir.getPath());
 		logger.info("Executing: {}", Joiner.on(" ").join(args));
 		Process process = new ProcessBuilder(args)
+			.directory(workDir)
 			.redirectErrorStream(true)
 			.start();
 		String output = IOUtils.toString(process.getInputStream());

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
@@ -105,7 +105,6 @@ public class ClosureCompiler {
 			File entryPoint,
 			Collection<File> inputSources,
 			Collection<File> customExterns,
-			CompilationLevel compilationLevel,
 			ClosureTarget target
 	) throws IOException, InterruptedException   {
 		File jarPath = copyJarFile(workDir, "/closure-compiler-wrapper.jar");

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/obfuscation/internal/ClosureCompiler.java
@@ -134,7 +134,7 @@ public class ClosureCompiler {
 
 		int retCode = process.waitFor();
 		if (retCode != 0) {
-			logger.error("Obfuscation error:" + output);
+			logger.error("ERROR: " + output);
 		}
 		return retCode;
 	}

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/ClosureCompilerTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/ClosureCompilerTest.groovy
@@ -13,10 +13,15 @@ class ClosureCompilerTest extends Specification {
         dir.mkdirs();
         File entryJs = new File(dir, "Entry.js");
         File moduleJs = new File(dir, "Module.js");
+        File externsJs = new File(dir, "Externs.js");
         File outputJs = new File(dir, "output.js")
         File obfuscatedJs = new File(dir, "obfuscated.js");
 
         when:
+        FileUtils.write(externsJs, """
+var prezi_module;
+""");
+
         FileUtils.write(entryJs, """
 prezi_module=require('./Module.js');
 """);
@@ -38,7 +43,9 @@ exports.translations = {
                 new File(entryJs.getName()),
                 new File(moduleJs.getName())
             ],
-            [],
+            [
+                new File(externsJs.getName()),
+            ],
             ClosureTarget.ES6);
 
         ClosureCompiler.compile(

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/ClosureCompilerTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/ClosureCompilerTest.groovy
@@ -1,0 +1,62 @@
+package com.prezi.spaghetti.obfuscation
+
+import java.nio.file.Files
+import com.prezi.spaghetti.obfuscation.internal.ClosureCompiler
+import com.prezi.spaghetti.obfuscation.ClosureTarget
+import com.prezi.spaghetti.obfuscation.CompilationLevel
+import org.apache.commons.io.FileUtils
+import spock.lang.Specification
+
+class ClosureCompilerTest extends Specification {
+    def "concat and then obfuscate doesn't rename quoted symbols"() {
+        File dir = Files.createTempDirectory("ClosureCompilerTest").toFile();
+        dir.mkdirs();
+        File entryJs = new File(dir, "Entry.js");
+        File moduleJs = new File(dir, "Module.js");
+        File outputJs = new File(dir, "output.js")
+        File obfuscatedJs = new File(dir, "obfuscated.js");
+
+        when:
+        FileUtils.write(entryJs, """
+prezi_module=require('./Module.js');
+""");
+
+        FileUtils.write(moduleJs, """
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.translations = {
+    "fr": [ "one", "two", "three" ],
+    "de": [ "one", "two", "three" ],
+};
+""");
+
+        ClosureCompiler.concat(
+            dir,
+            new File(outputJs.getName()),
+            new File(entryJs.getName()),
+            [
+                new File(entryJs.getName()),
+                new File(moduleJs.getName())
+            ],
+            [],
+            ClosureTarget.ES6);
+
+        ClosureCompiler.compile(
+            dir,
+            outputJs,
+            obfuscatedJs,
+            new File(dir, "source.map"),
+            CompilationLevel.ADVANCED,
+            [],
+            ClosureTarget.ES6)
+
+        then:
+        obfuscatedJs.text == [
+            'var a={};',
+            'Object.defineProperty(a,"__esModule",{value:!0});',
+            'a.a={fr:["one","two","three"],de:["one","two","three"]};',
+            'prezi_module=a;\n',
+        ].join("")
+
+    }
+}


### PR DESCRIPTION
Instead of calling Google Closure Compiler from the command line use closure-compiler-wrapper, a new small Java application that calls Google Closure Compiler's Java API directly.

This allows:
 * Fine-grained control of error messages so we can ignore undefined var errors, but still throw an error on circular references for es6 modules.
 * Fine-grained control over compilation level. We had to move the concat task to `WHITESPACE_ONLY` mode because it was messing up obfuscation by removing quotes from symbols that should be protected. Using the Java API we can go back to `SIMPLE_OPTIMIZATIONS` with `options.setConvertToDottedProperties(false);` to avoid this issue.

The obfuscation task still uses Google Closure Compiler from the command line, but if this change works in boxfish without issues then later I will make it use closure-compiler-wrapper as well.