### PR TITLE
Filter circular reference closure errors

### DIFF
--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/Args.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/Args.java
@@ -1,0 +1,50 @@
+package com.prezi.spaghetti.closure;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.io.File;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+
+class Args {
+    public static Args parse(String[] args) {
+        Args parsedArgs = new Args();
+        CmdLineParser parser = new CmdLineParser(parsedArgs);
+
+        try {
+            parser.parseArgument(args);
+        } catch (CmdLineException e) {
+            System.err.println(e.getMessage());
+            parser.printUsage(System.err);
+            System.exit(1);
+        }
+
+        return parsedArgs;
+    }
+
+    @Option(name="--js_output_file")
+    public File outputFile;
+
+    @Option(name="--create_source_map")
+    public File sourceMap = null;
+
+    @Option(name="--entry_point")
+    public List<String> entryPoints = new ArrayList<String>();
+
+    @Option(name="--js")
+    public List<String> inputPatterns = new ArrayList<String>();
+
+    @Option(name="--externs")
+    public List<String> externsPatterns = new ArrayList<String>();
+
+    @Option(name="--compilation_level")
+    public String compilationLevel = "SIMPLE";
+
+    @Option(name="--concat")
+    public boolean concat = false;
+
+    @Option(name="--es5")
+    public boolean es5 = false;
+}

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -35,6 +35,13 @@ class ClosureWrapper {
         Compiler compiler = new Compiler(System.err);
         CompilerOptions options = new CompilerOptions();
 
+        if (args.concat) {
+            compiler.setErrorManager(new FilteringErrorManager(
+                options.errorFormat.toFormatter(compiler, true),
+                System.err
+            ));
+        }
+
         CompilationLevel level = CompilationLevel.fromString(args.compilationLevel);
         if (level == null) {
             System.err.println("Invalid value for compilation_level: " + args.compilationLevel);
@@ -97,12 +104,11 @@ class ClosureWrapper {
         compiler.compile(externs, inputs, options);
 
         if (compiler.hasErrors()) {
-            JSError[] errors = compiler.getErrors();
-            for (JSError e : errors) {
+            for (JSError e : compiler.getErrors()) {
                 if (args.concat && e.getType() == EARLY_REFERENCE) {
                     System.err.println(String.format("The error '%s'", e.description));
-                    System.err.println("  likely means that there is a cycle in the module import graph.");
-                    System.err.println("  You must restructure the modules so there are no circular imports.");
+                    System.err.println("  likely means that there is a cycle in the module imports.");
+                    System.err.println("  Please refactor to avoid undefined errors at runtime.");
                     break;
                 }
             }

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -14,81 +14,20 @@ import com.google.javascript.jscomp.DiagnosticType;
 import com.google.javascript.jscomp.JSError;
 import com.google.javascript.jscomp.ModuleIdentifier;
 import com.google.javascript.jscomp.SourceFile;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.logging.Level;
 import java.util.ArrayList;
 import java.util.List;
-import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
 
-class Args {
-    @Option(name="--js_output_file")
-    public File outputFile;
-
-    @Option(name="--create_source_map")
-    public File sourceMap = null;
-
-    @Option(name="--entry_point")
-    public List<String> entryPoints = new ArrayList<String>();
-
-    @Option(name="--js")
-    public List<String> inputPatterns = new ArrayList<String>();
-
-    @Option(name="--externs")
-    public List<String> externsPatterns = new ArrayList<String>();
-
-    @Option(name="--compilation_level")
-    public String compilationLevel = "SIMPLE";
-
-    @Option(name="--concat")
-    public boolean concat = false;
-
-    @Option(name="--es5")
-    public boolean es5 = false;
-}
 
 class ClosureWrapper {
 
     static DiagnosticType EARLY_REFERENCE = findDiagnosticType("JSC_REFERENCE_BEFORE_DECLARE");
 
-    // VariableReferenceCheck is a protected class, so we have to access
-    // VariableReferenceCheck.EARLY_REFERENCE the hacky way.
-    static DiagnosticType findDiagnosticType(String key) {
-        for (DiagnosticType t : DiagnosticGroups.CHECK_VARIABLES.getTypes()) {
-            if (key.equals(t.key)) {
-                return t;
-            }
-        }
-
-        throw new RuntimeException("Cannot locate EARLY_REFERENCE");
-    }
-
-
-    private static List<ModuleIdentifier> getEntryPoints(List<String> entryFiles) {
-        List<ModuleIdentifier> entryPoints = new ArrayList<ModuleIdentifier>();
-        for (String s : entryFiles) {
-            entryPoints.add(ModuleIdentifier.forFile(s));
-        }
-        return entryPoints;
-    }
-
     public static void main(String[] args) throws IOException {
-        Args parsedArgs = new Args();
-        CmdLineParser parser = new CmdLineParser(parsedArgs);
-
-        try {
-            parser.parseArgument(args);
-        } catch (CmdLineException e) {
-            System.err.println(e.getMessage());
-            parser.printUsage(System.err);
-            return;
-        }
-
-        runCompiler(parsedArgs);
+        runCompiler(Args.parse(args));
     }
 
     private static void runCompiler(Args args) throws IOException {
@@ -182,5 +121,26 @@ class ClosureWrapper {
                 System.out.println("Wrote: " + args.sourceMap.getAbsolutePath());
             }
         }
+    }
+
+    // VariableReferenceCheck is a protected class, so we have to access
+    // VariableReferenceCheck.EARLY_REFERENCE the hacky way.
+    static DiagnosticType findDiagnosticType(String key) {
+        for (DiagnosticType t : DiagnosticGroups.CHECK_VARIABLES.getTypes()) {
+            if (key.equals(t.key)) {
+                return t;
+            }
+        }
+
+        throw new RuntimeException("Cannot locate EARLY_REFERENCE");
+    }
+
+
+    private static List<ModuleIdentifier> getEntryPoints(List<String> entryFiles) {
+        List<ModuleIdentifier> entryPoints = new ArrayList<ModuleIdentifier>();
+        for (String s : entryFiles) {
+            entryPoints.add(ModuleIdentifier.forFile(s));
+        }
+        return entryPoints;
     }
 }

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -52,6 +52,22 @@ class Args {
 }
 
 class ClosureWrapper {
+
+    static DiagnosticType EARLY_REFERENCE = findDiagnosticType("JSC_REFERENCE_BEFORE_DECLARE");
+
+    // VariableReferenceCheck is a protected class, so we have to access
+    // VariableReferenceCheck.EARLY_REFERENCE the hacky way.
+    static DiagnosticType findDiagnosticType(String key) {
+        for (DiagnosticType t : DiagnosticGroups.CHECK_VARIABLES.getTypes()) {
+            if (key.equals(t.key)) {
+                return t;
+            }
+        }
+
+        throw new RuntimeException("Cannot locate EARLY_REFERENCE");
+    }
+
+
     private static List<ModuleIdentifier> getEntryPoints(List<String> entryFiles) {
         List<ModuleIdentifier> entryPoints = new ArrayList<ModuleIdentifier>();
         for (String s : entryFiles) {
@@ -120,6 +136,14 @@ class ClosureWrapper {
         options.setWarningLevel(DiagnosticGroups.CHECK_VARIABLES, CheckLevel.OFF);
         options.setWarningLevel(DiagnosticGroups.CHECK_TYPES, CheckLevel.OFF);
 
+        if (args.concat) {
+            // Report an error if there is an import cycle in the module resolution.
+            // (ie. EARLY_REFERENCE, the module is referenced before it is defined).
+            options.setWarningLevel(
+                new DiagnosticGroup(EARLY_REFERENCE),
+                CheckLevel.ERROR);
+        }
+
         List<SourceFile> externs = new ArrayList<SourceFile>();
         externs.addAll(AbstractCommandLineRunner.getBuiltinExterns(options.getEnvironment()));
         for (String path : CommandLineRunner.findJsFiles(args.externsPatterns)) {
@@ -134,6 +158,15 @@ class ClosureWrapper {
         compiler.compile(externs, inputs, options);
 
         if (compiler.hasErrors()) {
+            JSError[] errors = compiler.getErrors();
+            for (JSError e : errors) {
+                if (args.concat && e.getType() == EARLY_REFERENCE) {
+                    System.err.println(String.format("The error '%s'", e.description));
+                    System.err.println("  likely means that there is a cycle in the module import graph.");
+                    System.err.println("  You must restructure the modules so there are no circular imports.");
+                    break;
+                }
+            }
             System.exit(1);
         } else {
             Writer writer = new FileWriter(args.outputFile);

--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/FilteringErrorManager.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/FilteringErrorManager.java
@@ -1,0 +1,63 @@
+package com.prezi.spaghetti.closure;
+
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.JSError;
+import com.google.javascript.jscomp.MessageFormatter;
+import com.google.javascript.jscomp.PrintStreamErrorManager;
+import com.google.javascript.rhino.Node;
+import java.io.PrintStream;
+
+
+class FilteringErrorManager extends PrintStreamErrorManager {
+    public FilteringErrorManager(MessageFormatter formatter, PrintStream stream) {
+        super(formatter, stream);
+    }
+
+    @Override
+    public void report(CheckLevel level, JSError error) {
+        if (isRequireAssignment(error.node)) {
+            // ignore this error
+        } else {
+            super.report(level, error);
+        }
+    }
+
+    private static boolean isRequireAssignment(Node nameNode) {
+        /*
+         * Google Closure Compiler transforms this:
+         *     const C_1 = require("./C");
+         * into this:
+         *     var C_1$$module$dist$A = module$dist$C.default;
+         *
+         * Then in a later pass, it removes the variable 'C_1$$module$dist$A'
+         * and inlines 'module$dist$C.default'. Therefore any early reference
+         * errors caused by this 'require()' assignment should be ignored.
+         *
+         * Here we detect the following AST:
+         *   CONST/VAR/LET
+         *    └─NAME 'C_1$$module$dist$A'
+         *       └─GETPROP
+         *          ├─NAME 'module$dist$C'  ⟵ value of 'nameNode'
+         *          └─STRING 'default'
+         */
+
+        Node sibling = nameNode.getNext();
+        Node parent = nameNode.getParent();
+        Node grandparent = nameNode.getGrandparent();
+        Node ggparent = grandparent == null ? null : grandparent.getParent();
+
+        return nameNode != null
+            && sibling != null
+            && parent != null
+            && grandparent != null
+            && nameNode.isName()
+            && nameNode.getString().startsWith("module$")
+            && sibling.isString()
+            && sibling.getString().equals("default")
+            && parent.isGetProp()
+            && grandparent.isName()
+            && grandparent.getString().contains("$$module$")
+            && ggparent != null
+            && (ggparent.isConst() || ggparent.isVar() || ggparent.isLet());
+    }
+}

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -128,11 +128,10 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 		File workDir = getWorkDir();
 		FileUtils.deleteQuietly(workDir);
 
-		File jsFilesDir = new File(workDir, "js");
-		File nodeDir = new File(jsFilesDir, "node_modules");
+		File nodeDir = new File(workDir, "node_modules");
 		FileUtils.forceMkdir(nodeDir);
 
-		FileUtils.copyDirectory(getSourceDir(), jsFilesDir);
+		FileUtils.copyDirectory(getSourceDir(), workDir);
 		ModuleConfiguration config = readConfig(getDefinition());
 
 		for (Map.Entry<String, String> extern : getDependencies(config, getExternalDependencies())) {
@@ -157,21 +156,21 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 		}
 
 		Collection<File> entryPointFiles = filterFileList(
-			FileUtils.listFiles(jsFilesDir, new String[] {"js"}, true),
+			FileUtils.listFiles(workDir, new String[] {"js"}, true),
 			getEntryPoints());
 		File mainEntryPoint = new File(workDir, "_spaghetti-entry.js");
 		ClosureUtils.writeMainEntryPoint(
 			mainEntryPoint,
 			entryPointFiles,
 			config.getLocalModule().getName());
-		File relativeJsDir = new File(jsFilesDir.getName());
+		File relativeJsDir = new File(".");
 		File relativeEntryPoint = new File(mainEntryPoint.getName());
 
 		int exitValue = ClosureCompiler.concat(
 			workDir,
 			getOutputFile(),
 			relativeEntryPoint,
-			Lists.newArrayList(relativeJsDir, relativeEntryPoint),
+			Lists.newArrayList(relativeJsDir),
 			Sets.<File>newHashSet(),
 			ObfuscationParameters.convertClosureTarget(getClosureTarget()));
 

--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/ClosureCompilerTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/obfuscation/ClosureCompilerTest.groovy
@@ -101,4 +101,37 @@ unknown.xx();
         outputJs.text.size() > 10
 
     }
+
+    def "circular import is an error"() {
+        File dir = Files.createTempDirectory("ClosureCompilerTest").toFile();
+        dir.mkdirs();
+        File entryJs = new File(dir, "Entry.js");
+        File moduleJs = new File(dir, "Module.js");
+        File outputJs = new File(dir, "output.js")
+
+        when:
+        FileUtils.write(entryJs, """
+prezi_module=require('./Module.js');
+""");
+
+        FileUtils.write(moduleJs, """
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+prezi_entry=require('./Entry.js');
+""");
+
+        def ret = ClosureCompiler.concat(
+            dir,
+            new File(outputJs.getName()),
+            new File(entryJs.getName()),
+            [
+                new File(entryJs.getName()),
+                new File(moduleJs.getName())
+            ],
+            [],
+            ClosureTarget.ES6);
+
+        then:
+        ret == 1
+    }
 }


### PR DESCRIPTION
It turns out that Closure Compiler can correctly catch the case that ES6 or commonjs modules are included in a bad order and a static reference (ie. class interitance, or other top level initialization) becomes undefined. The problem was that in addition to this, Closure Compiler reported *all* circular references as invalid early references (with the exact same message "Variable referenced before declaration").

Finally I have figured out how to ignore the latter (we should permit circular references) while still catching the static initializations which will be undefined. I do this by subclassing the compiler's ErrorManager and dropping an error being reports which matches a patter in the AST. The generated variable names (ie. "$$module$") are quite unique and predictable and so the checks in `isRequireAssignment` can be conservative preventing the possibility of false positives here.