### PR TITLE
Remove "use strict" from obfuscated js

### DIFF
--- a/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
+++ b/closure-compiler-wrapper/src/main/java/com/prezi/spaghetti/closure/ClosureWrapper.java
@@ -90,13 +90,14 @@ class ClosureWrapper {
             options.setSourceMapOutputPath(args.sourceMap.getPath());
         }
 
+        options.setEmitUseStrict(false);
+
         if (args.es5) {
             options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT5_STRICT);
             options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5_STRICT);
         } else {
             options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2015);
             options.setLanguageOut(CompilerOptions.LanguageMode.NO_TRANSPILE);
-            options.setEmitUseStrict(false);
             options.setRewritePolyfills(false);
         }
 


### PR DESCRIPTION
After obfuscation + wrapping we can end up with unusable modules like https://client-js.prezi.com/release/lib/prezi.engine.dom/33.0-1682-g5cb4d31/prezi.engine.dom.js

Problematic part:
```
var moduleImpl = (function() {
    return 'use strict';
    module(function(K) {
```