### PR TITLE
Protect attributes in type aliases from obfuscation

### DIFF
--- a/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
+++ b/spaghetti-core/src/test/groovy/com/prezi/spaghetti/tsast/TypeScriptAstParserServiceTest.groovy
@@ -28,8 +28,13 @@ declare module a.b.c {
 
     type XType = number | string;
 
+
+
     const ii:XInterface;
     function jj(xparam: number, xparam: string): { kk: number, ll: string };
+
+    export type ElementReference = string | XInterface | {m: string} | {n?: string} | {o: "viewport"};
+    export type FTypes = (no: string) => number;
 }
         """
         Set<String> symbols = TypeScriptAstParserService.collectExportedSymbols(dir, compilerPath, content, logger);
@@ -37,7 +42,7 @@ declare module a.b.c {
         then:
         def l = symbols.toList()
         l.sort()
-        l.join(",") == "a,b,c,d,e,f,g,hh,ii,jj,kk,ll"
+        l.join(",") == "a,b,c,d,e,f,g,hh,ii,jj,kk,ll,m,n,o"
     }
 
     def "classes not allowed"() {


### PR DESCRIPTION
Plugin api uses many types like this:
```
export type ElementReference = {uiElementId: string} | {preziElementId?: string} | {virtualElementId: "viewport"};
```

Since these are not interfaces, the attributes names were not protected from obfuscation.