### PR TITLE
Backwards compat headers

### DIFF
--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -200,8 +200,8 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 		Map<String, String> deps = Maps.newHashMap();
 		for (EntityWithModuleMetaData<ModuleNode> wrapper : config.getDirectDependentModules()) {
 			ModuleNode node = wrapper.getEntity();
-			String name = GeneratorUtils.namespaceToIdentifier(node.getName());
-			deps.put(name, name);
+			String ident = GeneratorUtils.namespaceToIdentifier(node.getName());
+			deps.put(ident, node.getName());
 		}
 		deps.putAll(externalDependencies);
 		return deps;

--- a/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
+++ b/gradle-spaghetti-typescript-plugin/src/main/java/com/prezi/spaghetti/typescript/gradle/internal/ClosureConcatenateTask.java
@@ -19,15 +19,11 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.prezi.spaghetti.ast.ModuleNode;
 import com.prezi.spaghetti.definition.DefinitionFile;
-import com.prezi.spaghetti.definition.EntityWithModuleMetaData;
 import com.prezi.spaghetti.definition.ModuleConfiguration;
-import com.prezi.spaghetti.generator.GeneratorUtils;
 import com.prezi.spaghetti.gradle.internal.AbstractDefinitionAwareSpaghettiTask;
 import com.prezi.spaghetti.gradle.internal.DefinitionAwareSpaghettiTask;
 import com.prezi.spaghetti.gradle.internal.ExternalDependencyAwareTask;
-import com.prezi.spaghetti.obfuscation.CompilationLevel;
 import com.prezi.spaghetti.obfuscation.internal.ClosureCompiler;
 
 public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask implements ExternalDependencyAwareTask, DefinitionAwareSpaghettiTask {
@@ -136,9 +132,8 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 		FileUtils.copyDirectory(getSourceDir(), workDir);
 		ModuleConfiguration config = readConfig(getDefinition());
 
-		ClosureCompiler.createExternAccessorsForConcat(
-			nodeDir,
-			getDependencies(config, getExternalDependencies()));
+		ClosureCompiler.createExternAccessorsForConcat(nodeDir, config);
+		ClosureCompiler.createExternAccessorsForConcat(nodeDir, getExternalDependencies());
 
 		for (String name : getNodeRequireDependencies()) {
 			FileUtils.write(
@@ -194,16 +189,5 @@ public class ClosureConcatenateTask extends AbstractDefinitionAwareSpaghettiTask
 			throw new RuntimeException("Cannot find entry points: " + Joiner.on(", ").join(names));
 		}
 		return foundFiles;
-	}
-
-	private static Map<String, String> getDependencies(ModuleConfiguration config, Map<String, String> externalDependencies) throws IOException {
-		Map<String, String> deps = Maps.newHashMap();
-		for (EntityWithModuleMetaData<ModuleNode> wrapper : config.getDirectDependentModules()) {
-			ModuleNode node = wrapper.getEntity();
-			String ident = GeneratorUtils.namespaceToIdentifier(node.getName());
-			deps.put(ident, node.getName());
-		}
-		deps.putAll(externalDependencies);
-		return deps;
 	}
 }

--- a/spaghetti-core/src/main/java/com/prezi/spaghetti/ast/internal/parser/SimpleTypeScriptDefinitionParser.java
+++ b/spaghetti-core/src/main/java/com/prezi/spaghetti/ast/internal/parser/SimpleTypeScriptDefinitionParser.java
@@ -13,7 +13,7 @@ public class SimpleTypeScriptDefinitionParser extends ModuleParser {
     public static final String DEFERRED_DTS_CONTENTS = "<< Definition contents will be generated later; if you see this string in a file it is likely a Spaghetti bug >>";
 
     private static final Pattern commonJsNamespacePattern =
-        Pattern.compile("export\\s+as\\s+namespace\\s+([a-zA-Z0-9_]+)\\s*;");
+        Pattern.compile("export\\s+as\\s+namespace\\s+([a-zA-Z0-9_\\.]+)\\s*;");
 
     public SimpleTypeScriptDefinitionParser(ModuleDefinitionSource source, String namespaceOverride) {
         super(null, createModuleNode(source, namespaceOverride));

--- a/spaghetti-support-test-harness/src/main/resources/DependencyModule.module.d.ts
+++ b/spaghetti-support-test-harness/src/main/resources/DependencyModule.module.d.ts
@@ -24,4 +24,4 @@ export module DependencyModule {
 	function createPointViaCallback(x: number, y: number, callback: (Point2d) => void): void;
 }
 
-export as namespace spaghetti_test_dependency;
+// export as namespace spaghetti.test.dependency;

--- a/spaghetti-support-test-harness/src/main/resources/TestModule.module.d.ts
+++ b/spaghetti-support-test-harness/src/main/resources/TestModule.module.d.ts
@@ -1,4 +1,4 @@
-import { Fruit, Prime, Point2d } from "spaghetti_test_dependency";
+import { Fruit, Prime, Point2d } from "spaghetti.test.dependency";
 
 /**
  * This enum should be exported on the compiled module.

--- a/spaghetti-support-test-harness/src/main/resources/TestModule.module.ts
+++ b/spaghetti-support-test-harness/src/main/resources/TestModule.module.ts
@@ -1,4 +1,4 @@
-import { Fruit, Prime, Point2d } from "spaghetti_test_dependency";
+import { Fruit, Prime, Point2d } from "spaghetti.test.dependency";
 import { TestModule } from "TestModule";
 
 export enum Exported {

--- a/spaghetti-typescript-support/src/integTest/groovy/com/prezi/spaghetti/typescript/TypeScriptGeneratorIntegrationTest.groovy
+++ b/spaghetti-typescript-support/src/integTest/groovy/com/prezi/spaghetti/typescript/TypeScriptGeneratorIntegrationTest.groovy
@@ -3,7 +3,6 @@ package com.prezi.spaghetti.typescript
 import org.apache.commons.io.FileUtils
 import com.prezi.spaghetti.ast.ModuleNode
 import com.prezi.spaghetti.definition.ModuleConfiguration
-import com.prezi.spaghetti.generator.GeneratorUtils
 import com.prezi.spaghetti.generator.HeaderGenerator
 import com.prezi.spaghetti.generator.JavaScriptBundleProcessor
 import com.prezi.spaghetti.generator.test.LanguageSupportSpecification
@@ -73,17 +72,13 @@ class TypeScriptGeneratorIntegrationTest extends LanguageSupportSpecification {
 			}
 		}
 
-		Map<String, String> externNames = moduleConfig.getDirectDependentModules().collectEntries { wrapper ->
-			String name = GeneratorUtils.namespaceToIdentifier(wrapper.entity.name);
-			return [ name, name ]
-		}
-		ClosureCompiler.createExternAccessorsForConcat(nodeModulesDir, externNames);
+		ClosureCompiler.createExternAccessorsForConcat(nodeModulesDir, moduleConfig);
 
 		File mainEntryPoint = new File(nodeModulesDir, "_spaghetti-entry.js");
 		ClosureCompiler.writeMainEntryPoint(
 			mainEntryPoint,
 			[ getFileEndingWith("module.js", [ nodeModulesDir ]) ],
-			GeneratorUtils.namespaceToIdentifier(moduleConfig.getLocalModule().getName()));
+			moduleConfig.getLocalModule().getName());
 
 		ClosureCompiler.concat(
 			closureDir,

--- a/spaghetti-typescript-support/src/integTest/module/src/TestModule.ts
+++ b/spaghetti-typescript-support/src/integTest/module/src/TestModule.ts
@@ -1,4 +1,4 @@
-import * as spaghetti_test_dependency from "spaghetti_test_dependency";
+import * as spaghetti_test_dependency from "spaghetti.test.dependency";
 import { Numbers, Point3d } from "TestModule.module";
 
 declare var libWithVersion: any;

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptDefinitionImportVisitor.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptDefinitionImportVisitor.groovy
@@ -27,7 +27,7 @@ class TypeScriptDefinitionImportVisitor extends ModuleVisitorBase<Set<String>> {
 		list.sort();
 		return list.collect { ns ->
 			def ident = GeneratorUtils.namespaceToIdentifier(ns)
-			return "import * as ${ident} from \"${ident}\";\n"
+			return "import * as ${ident} from \"${ns}\";\n"
 		}.join("")
 	}
 

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
@@ -120,7 +120,6 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 
 		def aliasImports = TypeScriptDefinitionImportVisitor.collectImports(module.entity, true);
 		def commonJsImports = TypeScriptDefinitionImportVisitor.collectImports(module.entity);
-		def underscoreName = GeneratorUtils.namespaceToIdentifier(module.entity.name);
 
 		// Backwards compatibility for commonjs header transition
 		def dtsContents = """
@@ -128,17 +127,15 @@ declare module ${module.entity.name} {
 ${aliasImports}
 ${contents}
 }
-declare module \"${underscoreName}\" {
+declare module \"${module.entity.name}\" {
 ${commonJsImports}
 ${contents}
 }
 """
-
 		writeTypeScriptDtsFile(module.entity, outputDirectory, header, dtsContents)
 	}
 
 	private static void writeTypeScriptDtsFile(ModuleNode module, File outputDirectory, String header, String content) {
-		String filename = GeneratorUtils.namespaceToIdentifier(module.name);
-		TypeScriptUtils.createSourceFile(header, filename + ".d.ts", outputDirectory, content);
+		TypeScriptUtils.createSourceFile(header, module.name + ".d.ts", outputDirectory, content);
 	}
 }

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptHeaderGenerator.groovy
@@ -94,7 +94,6 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 	private static void generateSpaghettiDependentModule(EntityWithModuleMetaData<ModuleNode> module, File outputDirectory, String header, boolean generateAccessor) {
 		def contents = ""
 		if (generateAccessor) {
-			contents += TypeScriptDefinitionImportVisitor.collectImports(module.entity)
 			contents += new TypeScriptModuleAccessorGeneratorVisitor(module.entity.name).visit(module.entity)
 			contents += new TypeScriptDefinitionIteratorVisitor(module.entity.name) {
 				@Override
@@ -107,7 +106,6 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 				}
 			}.visit(module.entity)
 		} else {
-			contents += TypeScriptDefinitionImportVisitor.collectImports(module.entity)
 			contents += new TypeScriptDefinitionIteratorVisitor(module.entity.name) {
 				@Override
 				String visitEnumNode(EnumNode node) {
@@ -119,7 +117,24 @@ class TypeScriptHeaderGenerator extends AbstractHeaderGenerator {
 				}
 			}.visit(module.entity)
 		}
-		writeTypeScriptDtsFile(module.entity, outputDirectory, header, contents)
+
+		def aliasImports = TypeScriptDefinitionImportVisitor.collectImports(module.entity, true);
+		def commonJsImports = TypeScriptDefinitionImportVisitor.collectImports(module.entity);
+		def underscoreName = GeneratorUtils.namespaceToIdentifier(module.entity.name);
+
+		// Backwards compatibility for commonjs header transition
+		def dtsContents = """
+declare module ${module.entity.name} {
+${aliasImports}
+${contents}
+}
+declare module \"${underscoreName}\" {
+${commonJsImports}
+${contents}
+}
+"""
+
+		writeTypeScriptDtsFile(module.entity, outputDirectory, header, dtsContents)
 	}
 
 	private static void writeTypeScriptDtsFile(ModuleNode module, File outputDirectory, String header, String content) {

--- a/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptJavaScriptBundleProcessor.groovy
+++ b/spaghetti-typescript-support/src/main/groovy/com/prezi/spaghetti/typescript/TypeScriptJavaScriptBundleProcessor.groovy
@@ -65,7 +65,13 @@ class TypeScriptJavaScriptBundleProcessor extends AbstractJavaScriptBundleProces
 		for (def wrapper: config.getDirectDependentModules()) {
 			ModuleNode module = wrapper.entity;
 			String value = GeneratorUtils.createModuleAccessor(module.name, wrapper.format);
-			lines.add(String.format("var %s=%s;", GeneratorUtils.namespaceToIdentifier(module.name), value));
+			String identName = GeneratorUtils.namespaceToIdentifier(module.name);
+			lines.add(String.format("var %s=%s;", identName, value));
+			if (identName != module.name) {
+				// Backwards compatibility for commonjs header transition: generate both underscored and non-underscore accessors
+				Collection<String> namespaceMerge = GeneratorUtils.createNamespaceMerge(module.name, identName);
+				lines.addAll(namespaceMerge);
+			}
 		}
 		for (def wrapper: config.getLazyDependentModules()) {
 			ModuleNode module = wrapper.entity;

--- a/spaghetti-typescript-support/src/test/groovy/com/prezi/spaghetti/typescript/TypeScriptDefinitionImportVisitorTest.groovy
+++ b/spaghetti-typescript-support/src/test/groovy/com/prezi/spaghetti/typescript/TypeScriptDefinitionImportVisitorTest.groovy
@@ -27,8 +27,8 @@ module com.example.test {
 		def result = TypeScriptDefinitionImportVisitor.namespacesToImports(namespaces)
 
 		expect:
-		result == """import * as com_example_other from "com_example_other";
-import * as com_example_other1 from "com_example_other1";
+		result == """import * as com_example_other from "com.example.other";
+import * as com_example_other1 from "com.example.other1";
 """
 	}
 }

--- a/spaghetti-typescript-support/src/test/groovy/com/prezi/spaghetti/typescript/TypeScriptJavaScriptBundleProcessorTest.groovy
+++ b/spaghetti-typescript-support/src/test/groovy/com/prezi/spaghetti/typescript/TypeScriptJavaScriptBundleProcessorTest.groovy
@@ -25,10 +25,19 @@ class TypeScriptJavaScriptBundleProcessorTest extends Specification {
 		then:
 		result == """var spaghetti_test_main=null;
 var com_a=Spaghetti["dependencies"]["com.a"];
+var com=(com||{});
+com.a=com_a;
 var com_b=Spaghetti["dependencies"]["com.b"];
+com.b=com_b;
 var spaghetti_other_dep=Spaghetti["dependencies"]["spaghetti.other.dep"];
+var spaghetti=(spaghetti||{});
+spaghetti.other=(spaghetti.other||{});
+spaghetti.other.dep=spaghetti_other_dep;
 var spaghetti_test_a=Spaghetti["dependencies"]["spaghetti.test.a"];
+spaghetti.test=(spaghetti.test||{});
+spaghetti.test.a=spaghetti_test_a;
 var spaghetti_test_dep=Spaghetti["dependencies"]["spaghetti.test.dep"];
+spaghetti.test.dep=spaghetti_test_dep;
 var get_com_lazy_first=Spaghetti["dependencies"]["com.lazy.first"];
 var get_com_lazy_second=Spaghetti["dependencies"]["com.lazy.second"];
 /* This is the JavaScript module */


### PR DESCRIPTION
Generate two kinds of typescript headers in the same file for backward compatibility:
 * Ambient global: `declare module prezi.geometry { ... }`
   * Can be used directly `prezi.geometry.Rectangle`
 * Ambient commonjs: `declare module "prezi.geometry" { ... }`
   * Can be used via es6 import: `import { Rectangle } from "prezi.geometry"`
This allows both commonJs and global accessors to work in the same file, easing the transition to commonjs imports.

This PR also reverts the conversion of all module names from dots to underscores (from Typescript's perspective). This makes it easier to match file names on disk with the imported string name.