### PR TITLE
⚠️ DO NOT MERGE YET! [DX-2647] update boxfish executor labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ tsc --version
 }
 
 stage("flow") {
-	node('boxfish-xenial-executor-small') {
+	node('boxfish-executor-small') {
 		checkout scm
 		ansiColor('xterm') {
 			def haxeHome = setupHaxe()


### PR DESCRIPTION
## Reason of the change

As part of ```xenial``` executor cleanup, we are moving to ```focal```. Executor labels have to be updated too.

Other activities:

[https://github.com/prezi/ci-v2-configs/pull/1445/files](https://github.com/prezi/ci-v2-configs/pull/1445/files)
